### PR TITLE
Add support for TypeScript, C++, Flutter SDK's

### DIFF
--- a/.github/workflows/ai-updater-specifics.yml
+++ b/.github/workflows/ai-updater-specifics.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: gabegottlob/viam-ai-updater
-          ref: experiment
+          ref: sdk-specifics
           path: viam-ai-updater
           token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/ai-updater-specifics.yml
+++ b/.github/workflows/ai-updater-specifics.yml
@@ -65,7 +65,7 @@ jobs:
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
         run: |
           cd viam-ai-updater/ai_updater
-          uv run python ai_updater.py --debug --work $GITHUB_WORKSPACE/sdk
+          uv run python ai_updater.py --debug --work $GITHUB_WORKSPACE/sdk --sdk ${{ inputs.sdk }}
           AI_SUMMARY=$(cat pr_summary.txt)
           echo "ai_summary<<EOT" >> $GITHUB_OUTPUT
           echo "$AI_SUMMARY" >> $GITHUB_OUTPUT

--- a/.github/workflows/ai-updater-specifics.yml
+++ b/.github/workflows/ai-updater-specifics.yml
@@ -8,6 +8,10 @@ on:
         description: "The branch to base the update on"
         required: true
         type: string
+      sdk:
+        description: "The SDK that is being updated (currently supports python, cpp, typescript, flutter)"
+        required: true
+        type: string
     secrets:
       GOOGLE_API_KEY:
         required: true
@@ -35,6 +39,10 @@ jobs:
       - name: Install tree command
         run: brew install tree
 
+      - name: Install dependencies for typescript (if necessary)
+        if: inputs.sdk == 'typescript'
+        run: brew install node npm protobuf protoc-gen-grpc-web
+
       - name: Install uv
         uses: astral-sh/setup-uv@v3
         with:
@@ -52,22 +60,32 @@ jobs:
           uv pip install -r viam-ai-updater/requirements.txt
 
       - name: Run ai-updater
+        id: ai-updater
         env:
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
         run: |
           cd viam-ai-updater/ai_updater
           uv run python ai_updater.py --debug --work $GITHUB_WORKSPACE/sdk
+          AI_SUMMARY=$(cat pr_summary.txt)
+          echo "ai_summary<<EOT" >> $GITHUB_OUTPUT
+          echo "$AI_SUMMARY" >> $GITHUB_OUTPUT
+          echo "EOT" >> $GITHUB_OUTPUT
 
       - name: Add + Commit + Open PR
         id: cpr
         uses: peter-evans/create-pull-request@v7
         with:
-          commit-message: '[WORKFLOW] AI update based on proto changes'
+          commit-message: '[WORKFLOW] AI update based on proto changes from commit ${{ github.event.head_commit.id }}'
           path: sdk
           branch: workflow/ai-updater
+          delete-branch: true
           base: main
           title: AI update based on proto changes
-          body: This is an AI-generated PR to update the SDK based on proto changes. The AI may make mistakes so review carefully.
+          body: |
+            This is an AI-generated PR to update the SDK based on proto changes. The AI may make mistakes so review carefully.
+
+            **Summary of Changes:**
+            ${{ steps.ai-updater.outputs.ai_summary }}
           assignees: gabegottlob
           reviewers: gabegottlob
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ai-updater.yml
+++ b/.github/workflows/ai-updater.yml
@@ -61,23 +61,32 @@ jobs:
           uv pip install -r viam-ai-updater/requirements.txt
 
       - name: Run ai-updater
+        id: ai-updater
         env:
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
         run: |
           cd viam-ai-updater/ai_updater
           uv run python ai_updater.py --debug --work $GITHUB_WORKSPACE/sdk
+          AI_SUMMARY=$(cat pr_summary.txt)
+          echo "ai_summary<<EOT" >> $GITHUB_OUTPUT
+          echo "$AI_SUMMARY" >> $GITHUB_OUTPUT
+          echo "EOT" >> $GITHUB_OUTPUT
 
       - name: Add + Commit + Open PR
         id: cpr
         uses: peter-evans/create-pull-request@v7
         with:
-          commit-message: '[WORKFLOW] AI update based on proto changes'
+          commit-message: '[WORKFLOW] AI update based on proto changes from commit ${{ github.event.head_commit.id }}'
           path: sdk
           branch: workflow/ai-updater
           delete-branch: true
           base: main
           title: AI update based on proto changes
-          body: This is an AI-generated PR to update the SDK based on proto changes. The AI may make mistakes so review carefully.
+          body: |
+            This is an AI-generated PR to update the SDK based on proto changes. The AI may make mistakes so review carefully.
+
+            **Summary of Changes:**
+            ${{ steps.ai-updater.outputs.ai_summary }}
           assignees: gabegottlob
           reviewers: gabegottlob
           token: ${{ secrets.GIT_ACCESS_TOKEN }}

--- a/.github/workflows/ai-updater.yml
+++ b/.github/workflows/ai-updater.yml
@@ -8,8 +8,14 @@ on:
         description: "The branch to base the update on"
         required: true
         type: string
+      sdk:
+        description: "The SDK that is being updated (currently supports python, cpp, typescript, flutter)"
+        required: true
+        type: string
     secrets:
       GOOGLE_API_KEY:
+        required: true
+      GIT_ACCESS_TOKEN:
         required: true
 
 jobs:
@@ -33,6 +39,10 @@ jobs:
 
       - name: Install tree command
         run: brew install tree
+
+      - name: Install dependencies for typescript (if necessary)
+        if: inputs.sdk == 'typescript'
+        run: brew install node npm protobuf protoc-gen-grpc-web
 
       - name: Install uv
         uses: astral-sh/setup-uv@v3
@@ -64,10 +74,11 @@ jobs:
           commit-message: '[WORKFLOW] AI update based on proto changes'
           path: sdk
           branch: workflow/ai-updater
+          delete-branch: true
           base: main
           title: AI update based on proto changes
           body: This is an AI-generated PR to update the SDK based on proto changes. The AI may make mistakes so review carefully.
           assignees: gabegottlob
           reviewers: gabegottlob
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GIT_ACCESS_TOKEN }}
           draft: true

--- a/.github/workflows/ai-updater.yml
+++ b/.github/workflows/ai-updater.yml
@@ -15,8 +15,8 @@ on:
     secrets:
       GOOGLE_API_KEY:
         required: true
-      # GIT_ACCESS_TOKEN:
-      #   required: true
+      GIT_ACCESS_TOKEN:
+        required: true
 
 jobs:
   run-ai-updater:
@@ -89,6 +89,5 @@ jobs:
             ${{ steps.ai-updater.outputs.ai_summary }}
           assignees: gabegottlob
           reviewers: gabegottlob
-          #token: ${{ secrets.GIT_ACCESS_TOKEN }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GIT_ACCESS_TOKEN }}
           draft: true

--- a/.github/workflows/ai-updater.yml
+++ b/.github/workflows/ai-updater.yml
@@ -15,8 +15,8 @@ on:
     secrets:
       GOOGLE_API_KEY:
         required: true
-      GIT_ACCESS_TOKEN:
-        required: true
+      # GIT_ACCESS_TOKEN:
+      #   required: true
 
 jobs:
   run-ai-updater:
@@ -89,5 +89,6 @@ jobs:
             ${{ steps.ai-updater.outputs.ai_summary }}
           assignees: gabegottlob
           reviewers: gabegottlob
-          token: ${{ secrets.GIT_ACCESS_TOKEN }}
+          #token: ${{ secrets.GIT_ACCESS_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           draft: true

--- a/.github/workflows/ai-updater.yml
+++ b/.github/workflows/ai-updater.yml
@@ -66,7 +66,7 @@ jobs:
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
         run: |
           cd viam-ai-updater/ai_updater
-          uv run python ai_updater.py --debug --work $GITHUB_WORKSPACE/sdk
+          uv run python ai_updater.py --debug --work $GITHUB_WORKSPACE/sdk --sdk ${{ inputs.sdk }}
           AI_SUMMARY=$(cat pr_summary.txt)
           echo "ai_summary<<EOT" >> $GITHUB_OUTPUT
           echo "$AI_SUMMARY" >> $GITHUB_OUTPUT

--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,5 @@ ai_updater/*.txt
 ai_updater/scenario-*/ai_generated/
 .vscode/launch.json
 .venv/
-src/
-tests/
+/src/
+/tests/

--- a/ai_updater/prompts/applychanges_prompts.py
+++ b/ai_updater/prompts/applychanges_prompts.py
@@ -124,3 +124,13 @@ Generate two equal-length lists:
 
 Begin by carefully reading the implementation requirements and file content, then generate your patches.
 """
+
+GENERATESUMMARY_P = '''You are an expert technical writer, adept at summarizing code changes from a git diff and a list of required changes. Your goal is to provide a concise, human-readable summary that can be used in a pull request body. Focus on the core purpose of the changes and their impact, not line-by-line details. The summary should be a short paragraph or a few bullet points.
+
+Here is the original git diff that led to the changes:
+{git_diff_output}
+
+Here is the AI's analysis of the required code changes, including files to update and implementation details:
+{diff_analysis_text}
+
+Provide a summary of the changes. The summary should be concise and easy to understand for a reviewer.'''

--- a/ai_updater/tests/scenario-5/expected/src/viam/app/data_client.py
+++ b/ai_updater/tests/scenario-5/expected/src/viam/app/data_client.py
@@ -1,0 +1,2037 @@
+import warnings
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple, Union, cast
+
+import bson
+from google.protobuf.struct_pb2 import Struct
+from grpclib.client import Channel, Stream
+from typing_extensions import Self
+
+from viam import logging
+from viam.proto.app.data import (
+    AddBinaryDataToDatasetByIDsRequest,
+    AddBoundingBoxToImageByIDRequest,
+    AddBoundingBoxToImageByIDResponse,
+    AddTagsToBinaryDataByFilterRequest,
+    AddTagsToBinaryDataByIDsRequest,
+    BinaryData,
+    BinaryDataByFilterRequest,
+    BinaryDataByFilterResponse,
+    BinaryDataByIDsRequest,
+    BinaryDataByIDsResponse,
+    BinaryID,
+    BoundingBoxLabelsByFilterRequest,
+    BoundingBoxLabelsByFilterResponse,
+    CaptureInterval,
+    CaptureMetadata,
+    ConfigureDatabaseUserRequest,
+    DataRequest,
+    DataServiceStub,
+    DeleteBinaryDataByFilterRequest,
+    DeleteBinaryDataByFilterResponse,
+    DeleteBinaryDataByIDsRequest,
+    DeleteBinaryDataByIDsResponse,
+    DeleteTabularDataRequest,
+    DeleteTabularDataResponse,
+    ExportTabularDataRequest,
+    ExportTabularDataResponse,
+    Filter,
+    GetDatabaseConnectionRequest,
+    GetDatabaseConnectionResponse,
+    GetLatestTabularDataRequest,
+    GetLatestTabularDataResponse,
+    Order,
+    RemoveBinaryDataFromDatasetByIDsRequest,
+    RemoveBoundingBoxFromImageByIDRequest,
+    RemoveTagsFromBinaryDataByFilterRequest,
+    RemoveTagsFromBinaryDataByFilterResponse,
+    RemoveTagsFromBinaryDataByIDsRequest,
+    RemoveTagsFromBinaryDataByIDsResponse,
+    TabularDataByFilterRequest,
+    TabularDataByFilterResponse,
+    TabularDataByMQLRequest,
+    TabularDataByMQLResponse,
+    TabularDataBySQLRequest,
+    TabularDataBySQLResponse,
+    TabularDataSource,
+    TabularDataSourceType,
+    TagsByFilterRequest,
+    TagsByFilterResponse,
+)
+from viam.proto.app.datapipelines import (
+    CreateDataPipelineRequest,
+    CreateDataPipelineResponse,
+    DataPipelineRunStatus,
+    DataPipelinesServiceStub,
+    DeleteDataPipelineRequest,
+    GetDataPipelineRequest,
+    GetDataPipelineResponse,
+    ListDataPipelineRunsRequest,
+    ListDataPipelineRunsResponse,
+    ListDataPipelinesRequest,
+    ListDataPipelinesResponse,
+)
+from viam.proto.app.datapipelines import (
+    DataPipeline as ProtoDataPipeline,
+)
+from viam.proto.app.datapipelines import (
+    DataPipelineRun as ProtoDataPipelineRun,
+)
+from viam.proto.app.dataset import (
+    CreateDatasetRequest,
+    CreateDatasetResponse,
+    Dataset,
+    DatasetServiceStub,
+    DeleteDatasetRequest,
+    ListDatasetsByIDsRequest,
+    ListDatasetsByIDsResponse,
+    ListDatasetsByOrganizationIDRequest,
+    ListDatasetsByOrganizationIDResponse,
+    RenameDatasetRequest,
+)
+from viam.proto.app.datasync import (
+    DataCaptureUploadMetadata,
+    DataCaptureUploadRequest,
+    DataCaptureUploadResponse,
+    DataSyncServiceStub,
+    DataType,
+    FileData,
+    FileUploadRequest,
+    FileUploadResponse,
+    SensorData,
+    SensorMetadata,
+    StreamingDataCaptureUploadRequest,
+    StreamingDataCaptureUploadResponse,
+    UploadMetadata,
+)
+from viam.utils import ValueTypes, _alias_param, create_filter, datetime_to_timestamp, dict_to_struct, struct_to_dict
+
+LOGGER = logging.getLogger(__name__)
+
+
+class DataClient:
+    """gRPC client for uploading and retrieving data from app.
+
+    This class's constructor instantiates relevant service stubs. Always make :class:`DataClient` method calls through an instance of
+    :class:`ViamClient`.
+
+    Establish a connection::
+
+        import asyncio
+
+        from viam.rpc.dial import DialOptions, Credentials
+        from viam.app.viam_client import ViamClient
+
+
+        async def connect() -> ViamClient:
+            # Replace "<API-KEY>" (including brackets) with your API key and "<API-KEY-ID>" with your API key ID
+            dial_options = DialOptions.with_api_key("<API-KEY>", "<API-KEY-ID>")
+            return await ViamClient.create_from_dial_options(dial_options)
+
+
+        async def main():
+            # Make a ViamClient
+            viam_client = await connect()
+            # Instantiate a DataClient to run data client API methods on
+            data_client = viam_client.data_client
+
+            viam_client.close()
+
+        if __name__ == '__main__':
+            asyncio.run(main())
+
+
+    For more information, see `Data Client API <https://docs.viam.com/dev/reference/apis/data-client/>`_.
+    """
+
+    @dataclass
+    class TabularData:
+        """Class representing a piece of tabular data and associated metadata."""
+
+        data: Mapping[str, Any]
+        """The requested data"""
+
+        metadata: CaptureMetadata
+        """The metadata associated with the data"""
+
+        time_requested: datetime
+        """The time the data were requested"""
+
+        time_received: datetime
+        """The time the data were received"""
+
+        def __str__(self) -> str:
+            return f"{self.data}\n{self.metadata}Time requested: {self.time_requested}\nTime received: {self.time_received}\n"
+
+        def __eq__(self, other: object) -> bool:
+            if isinstance(other, DataClient.TabularData):
+                return str(self) == str(other)
+            return False
+
+    @dataclass
+    class TabularDataPoint:
+        """Represents a tabular data point and its associated metadata."""
+
+        part_id: str
+        """The robot part ID"""
+
+        resource_name: str
+        """The resource name"""
+
+        resource_api: str
+        """The resource API. For example, rdk:component:sensor"""
+
+        method_name: str
+        """The method used for data capture. For example, Readings"""
+
+        time_captured: datetime
+        """The time at which the data point was captured"""
+
+        organization_id: str
+        """The organization ID"""
+
+        location_id: str
+        """The location ID"""
+
+        robot_name: str
+        """The robot name"""
+
+        robot_id: str
+        """The robot ID"""
+
+        part_name: str
+        """The robot part name"""
+
+        method_parameters: Mapping[str, ValueTypes]
+        """Additional parameters associated with the data capture method"""
+
+        tags: List[str]
+        """A list of tags associated with the data point"""
+
+        payload: Mapping[str, ValueTypes]
+        """The captured data"""
+
+        def __str__(self) -> str:
+            return (
+                f"TabularDataPoint("
+                f"robot='{self.robot_name}' (id={self.robot_id}), "
+                f"part='{self.part_name}' (id={self.part_id}), "
+                f"resource='{self.resource_name}' ({self.resource_api}), "
+                f"method='{self.method_name}', "
+                f"org={self.organization_id}, "
+                f"location={self.location_id}, "
+                f"time='{self.time_captured.isoformat()}', "
+                f"params={self.method_parameters}, "
+                f"tags={self.tags}, "
+                f"payload={self.payload})"
+            )
+
+        def __eq__(self, other: object) -> bool:
+            if isinstance(other, DataClient.TabularDataPoint):
+                return str(self) == str(other)
+            return False
+
+        @property
+        def resource_subtype(self) -> str:
+            warnings.warn(
+                "`TabularDataPoint.resource_subtype` is deprecated. Use `TabularDataPoint.resource_api` instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            return self.resource_api
+
+    @dataclass
+    class DataPipeline:
+        """Represents a data pipeline and its associated metadata."""
+
+        id: str
+        """The ID of the data pipeline"""
+
+        organization_id: str
+        """The organization ID"""
+
+        name: str
+        """The name of the data pipeline"""
+
+        mql_binary: List[Dict[str, Any]]
+        """The MQL binary of the data pipeline"""
+
+        schedule: str
+        """The schedule of the data pipeline"""
+
+        created_on: datetime
+        """The time the data pipeline was created"""
+
+        updated_at: datetime
+        """The time the data pipeline was last updated"""
+
+        enabled: bool
+        """Whether the data pipeline is enabled"""
+
+        data_source_type: TabularDataSourceType.ValueType
+        """The type of data source for the data pipeline"""
+
+        @classmethod
+        def from_proto(cls, data_pipeline: ProtoDataPipeline) -> Self:
+            return cls(
+                id=data_pipeline.id,
+                organization_id=data_pipeline.organization_id,
+                name=data_pipeline.name,
+                mql_binary=[bson.decode(bson_bytes) for bson_bytes in data_pipeline.mql_binary],
+                schedule=data_pipeline.schedule,
+                created_on=data_pipeline.created_on.ToDatetime(),
+                updated_at=data_pipeline.updated_at.ToDatetime(),
+                enabled=data_pipeline.enabled,
+                data_source_type=data_pipeline.data_source_type,
+            )
+
+    @dataclass
+    class DataPipelineRun:
+        """Represents a data pipeline run and its associated metadata."""
+
+        id: str
+        """The ID of the data pipeline run"""
+
+        status: DataPipelineRunStatus.ValueType
+        """The status of the data pipeline run"""
+
+        start_time: datetime
+        """The time the data pipeline run started"""
+
+        end_time: datetime
+        """The time the data pipeline run ended"""
+
+        data_start_time: datetime
+        """The start time of the data that was processed in the run."""
+        data_end_time: datetime
+        """The end time of the data that was processed in the run."""
+
+        @classmethod
+        def from_proto(cls, data_pipeline_run: ProtoDataPipelineRun) -> Self:
+            return cls(
+                id=data_pipeline_run.id,
+                status=data_pipeline_run.status,
+                start_time=data_pipeline_run.start_time.ToDatetime(),
+                end_time=data_pipeline_run.end_time.ToDatetime(),
+                data_start_time=data_pipeline_run.data_start_time.ToDatetime(),
+                data_end_time=data_pipeline_run.data_end_time.ToDatetime(),
+            )
+
+    @dataclass
+    class DataPipelineRunsPage:
+        """Represents a page of data pipeline runs and provides pagination functionality."""
+
+        _client: "DataClient"
+        """The data client used to make API calls"""
+
+        pipeline_id: str
+        """The ID of the pipeline these runs belong to"""
+
+        page_size: int
+        """The number of runs per page"""
+
+        runs: List["DataClient.DataPipelineRun"]
+        """The list of runs in this page"""
+
+        next_page_token: str
+        """The token to use to get the next page of results"""
+
+        async def next_page(self) -> "DataClient.DataPipelineRunsPage":
+            """Get the next page of data pipeline runs.
+
+            Returns:
+                DataPipelineRunsPage: The next page of runs, or an empty page if there are no more runs
+            """
+            if not self.next_page_token:
+                # no token, return empty next page
+                return DataClient.DataPipelineRunsPage(
+                    _client=self._client, pipeline_id=self.pipeline_id, page_size=self.page_size, runs=[], next_page_token=""
+                )
+            return await self._client._list_data_pipeline_runs(self.pipeline_id, self.page_size, self.next_page_token)
+
+        @classmethod
+        def from_proto(cls, data_pipeline_runs_page: ListDataPipelineRunsResponse, client: "DataClient", page_size: int) -> Self:
+            return cls(
+                _client=client,
+                pipeline_id=data_pipeline_runs_page.pipeline_id,
+                page_size=page_size,
+                runs=[DataClient.DataPipelineRun.from_proto(run) for run in data_pipeline_runs_page.runs],
+                next_page_token=data_pipeline_runs_page.next_page_token,
+            )
+
+    def __init__(self, channel: Channel, metadata: Mapping[str, str]):
+        """Create a :class:`DataClient` that maintains a connection to app.
+
+        Args:
+            channel (grpclib.client.Channel): Connection to app.
+            metadata (Mapping[str, str]): Required authorization token to send requests to app.
+        """
+        self._metadata = metadata
+        self._data_client = DataServiceStub(channel)
+        self._data_sync_client = DataSyncServiceStub(channel)
+        self._dataset_client = DatasetServiceStub(channel)
+        self._data_pipelines_client = DataPipelinesServiceStub(channel)
+        self._channel = channel
+
+    _data_client: DataServiceStub
+    _data_sync_client: DataSyncServiceStub
+    _dataset_client: DatasetServiceStub
+    _data_pipelines_client: DataPipelinesServiceStub
+    _metadata: Mapping[str, str]
+    _channel: Channel
+
+    async def tabular_data_by_filter(
+        self,
+        filter: Optional[Filter] = None,
+        limit: Optional[int] = None,
+        sort_order: Optional[Order.ValueType] = None,
+        last: Optional[str] = None,
+        count_only: bool = False,
+        include_internal_data: bool = False,
+        dest: Optional[str] = None,
+    ) -> Tuple[List[TabularData], int, str]:
+        """Filter and download tabular data. The data will be paginated into pages of ``limit`` items; the returned tuple will include
+        the pagination ID. If a destination is provided, this method saves returned data to that file, overwriting any existing file content.
+
+        ::
+
+            from viam.utils import create_filter
+
+            my_data = []
+            my_filter = create_filter(component_name="motor-1")
+            last = None
+            while True:
+                tabular_data, count, last = await data_client.tabular_data_by_filter(my_filter, last=last)
+                if not tabular_data:
+                    break
+                my_data.extend(tabular_data)
+
+            print(f"My data: {my_data}")
+
+        Args:
+            filter (~viam.proto.app.data.Filter): Optional, specifies tabular data to retrieve. If missing, matches all tabular data.
+            limit (int): The maximum number of entries to include in a page. Defaults to 50 if unspecified.
+            sort_order (~viam.proto.app.data.Order): The desired sort order of the data.
+            last (str): Optional string indicating the object identifier of the last-returned data.
+                Returned by calls to :class:`TabularDataByFilter` as the ``last`` value.
+                If provided, the server returns the next data entries after the last object identifier.
+            count_only (bool): Whether to return only the total count of entries.
+            include_internal_data (bool): Whether to return the internal data. Internal data is used for Viam-specific data ingestion,
+                like cloud SLAM. Defaults to ``False``.
+            dest (str): Optional filepath for writing retrieved data.
+
+        Returns:
+            Tuple[List[TabularData], int, str]: A tuple containing the following:
+
+                - ``tabular_data`` (*List[TabularData]*): The tabular data.
+                - ``count`` (*int*): The count (number of entries).
+                - ``last`` (*str*): The last-returned page ID.
+
+        For more information, see `Data Client API <https://docs.viam.com/dev/reference/apis/data-client/#tabulardatabyfilter>`_.
+        """
+        filter = filter if filter else Filter()
+
+        data_request = DataRequest(filter=filter)
+        if limit:
+            data_request.limit = limit
+        if sort_order:
+            data_request.sort_order = sort_order
+        if last:
+            data_request.last = last
+        request = TabularDataByFilterRequest(data_request=data_request, count_only=count_only, include_internal_data=include_internal_data)
+        response: TabularDataByFilterResponse = await self._data_client.TabularDataByFilter(request, metadata=self._metadata)
+        data = [
+            DataClient.TabularData(
+                struct_to_dict(struct.data),
+                response.metadata[struct.metadata_index],
+                struct.time_requested.ToDatetime(),
+                struct.time_received.ToDatetime(),
+            )
+            for struct in response.data
+        ]
+
+        if dest:
+            try:
+                file = open(dest, "w")
+                file.write(f"{[str(d) for d in data]}")
+                file.flush()
+            except Exception as e:
+                LOGGER.error(f"Failed to write tabular data to file {dest}", exc_info=e)
+        return data, response.count, response.last
+
+    async def tabular_data_by_sql(self, organization_id: str, sql_query: str) -> List[Dict[str, Union[ValueTypes, datetime]]]:
+        """Obtain unified tabular data and metadata, queried with SQL.
+        Make sure your API key has permissions at the organization level in order to use this.
+
+        ::
+
+            data = await data_client.tabular_data_by_sql(
+                organization_id="<YOUR-ORG-ID>",
+                sql_query="SELECT * FROM readings LIMIT 5"
+            )
+
+        Args:
+            organization_id (str): The ID of the organization that owns the data.
+                To find your organization ID, visit the organization settings page.
+            sql_query (str): The SQL query to run.
+
+        Returns:
+            List[Dict[str, Union[ValueTypes, datetime]]]: An array of decoded BSON data objects.
+
+        For more information, see `Data Client API <https://docs.viam.com/dev/reference/apis/data-client/#tabulardatabysql>`_.
+        """
+        request = TabularDataBySQLRequest(organization_id=organization_id, sql_query=sql_query)
+        response: TabularDataBySQLResponse = await self._data_client.TabularDataBySQL(request, metadata=self._metadata)
+        return [bson.decode(bson_bytes) for bson_bytes in response.raw_data]
+
+    @_alias_param("query", param_alias="mql_binary")
+    async def tabular_data_by_mql(
+        self,
+        organization_id: str,
+        query: Union[List[bytes], List[Dict[str, Any]]],
+        use_recent_data: Optional[bool] = None,
+        tabular_data_source_type: TabularDataSourceType.ValueType = TabularDataSourceType.TABULAR_DATA_SOURCE_TYPE_STANDARD,
+        pipeline_id: Optional[str] = None,
+    ) -> List[Dict[str, Union[ValueTypes, datetime]]]:
+        """Obtain unified tabular data and metadata, queried with MQL.
+
+        ::
+
+            import bson
+
+            tabular_data = await data_client.tabular_data_by_mql(organization_id="<YOUR-ORG-ID>", query=[
+                { '$match': { 'location_id': '<YOUR-LOCATION-ID>' } },
+                { "$limit": 5 }
+            ])
+
+            print(f"Tabular Data: {tabular_data}")
+
+        Args:
+            organization_id (str): The ID of the organization that owns the data.
+                To find your organization ID, visit the organization settings page.
+            query (Union[List[bytes], List[Dict[str, Any]]]): The MQL query to run, as a list of MongoDB aggregation pipeline stages.
+                Each stage can be provided as either a dictionary or raw BSON bytes, but support for bytes will be removed in the
+                future, so prefer the dictionary option.
+            use_recent_data (bool): Whether to query blob storage or your recent data store. Defaults to ``False``..
+                Deprecated, use `tabular_data_source_type` instead.
+            tabular_data_source_type (viam.proto.app.data.TabularDataSourceType): The data source to query.
+                Defaults to `TABULAR_DATA_SOURCE_TYPE_STANDARD`.
+            pipeline_id (str): The ID of the data pipeline to query. Defaults to `None`.
+                Required if `tabular_data_source_type` is `TABULAR_DATA_SOURCE_TYPE_PIPELINE_SINK`.
+
+        Returns:
+            List[Dict[str, Union[ValueTypes, datetime]]]: An array of decoded BSON data objects.
+
+        For more information, see `Data Client API <https://docs.viam.com/dev/reference/apis/data-client/#tabulardatabymql>`_.
+        """
+        binary: List[bytes] = [bson.encode(query) for query in query] if isinstance(query[0], dict) else query  # type: ignore
+        data_source = TabularDataSource(type=tabular_data_source_type, pipeline_id=pipeline_id)
+        if use_recent_data:
+            data_source.type = TabularDataSourceType.TABULAR_DATA_SOURCE_TYPE_HOT_STORAGE
+        request = TabularDataByMQLRequest(organization_id=organization_id, mql_binary=binary, data_source=data_source)
+        response: TabularDataByMQLResponse = await self._data_client.TabularDataByMQL(request, metadata=self._metadata)
+        return [bson.decode(bson_bytes) for bson_bytes in response.raw_data]
+
+    @_alias_param("resource_api", param_alias="resource_subtype")
+    async def get_latest_tabular_data(
+        self,
+        part_id: str,
+        resource_name: str,
+        resource_api: str,
+        method_name: str,
+        additional_params: Optional[Mapping[str, ValueTypes]] = None,
+    ) -> Optional[Tuple[datetime, datetime, Dict[str, ValueTypes]]]:
+        """Gets the most recent tabular data captured from the specified data source, as long as it was synced within the last year.
+
+        ::
+
+            tabular_data = await data_client.get_latest_tabular_data(
+                part_id="77ae3145-7b91-123a-a234-e567cdca8910",
+                resource_name="camera-1",
+                resource_api="rdk:component:camera",
+                method_name="GetImage",
+                additional_params={"docommand_input": {"test": "test"}}
+            )
+
+            if tabular_data:
+                time_captured, time_synced, payload = tabular_data
+                print(f"Time Captured: {time_captured}")
+                print(f"Time Synced: {time_synced}")
+                print(f"Payload: {payload}")
+            else:
+                print(f"No data returned: {tabular_data}")
+
+        Args:
+            part_id (str): The ID of the part that owns the data.
+            resource_name (str): The name of the requested resource that captured the data. For example, "my-sensor".
+            resource_api (str): The API of the requested resource that captured the data. For example, "rdk:component:sensor".
+            method_name (str): The data capture method name. For exampe, "Readings".
+            additional_params (dict): Optional additional parameters of the resource that captured the data.
+
+        Returns:
+            Optional[Tuple[datetime, datetime, Dict[str, ValueTypes]]]:
+            A return value of ``None`` means that this data source
+            has not synced data in the last year. Otherwise, the data source has synced some data in the last year, so the returned
+            tuple contains the following:
+
+                - ``time_captured`` (*datetime*): The time captured.
+                - ``time_synced`` (*datetime*): The time synced.
+                - ``payload`` (*Dict[str, ValueTypes]*): The latest tabular data captured from the specified data source.
+
+        For more information, see `Data Client API <https://docs.viam.com/dev/reference/apis/data-client/#getlatesttabulardata>`_.
+        """
+
+        request = GetLatestTabularDataRequest(
+            part_id=part_id,
+            resource_name=resource_name,
+            resource_subtype=resource_api,
+            method_name=method_name,
+            additional_parameters=dict_to_struct(additional_params),
+        )
+        response: GetLatestTabularDataResponse = await self._data_client.GetLatestTabularData(request, metadata=self._metadata)
+        if not response.payload:
+            return None
+        return response.time_captured.ToDatetime(), response.time_synced.ToDatetime(), struct_to_dict(response.payload)
+
+    @_alias_param("resource_api", param_alias="resource_subtype")
+    async def export_tabular_data(
+        self,
+        part_id: str,
+        resource_name: str,
+        resource_api: str,
+        method_name: str,
+        start_time: Optional[datetime] = None,
+        end_time: Optional[datetime] = None,
+        additional_params: Optional[Mapping[str, ValueTypes]] = None,
+    ) -> List[TabularDataPoint]:
+        """Obtain unified tabular data and metadata from the specified data source.
+
+        ::
+
+            tabular_data = await data_client.export_tabular_data(
+                part_id="<PART-ID>",
+                resource_name="<RESOURCE-NAME>",
+                resource_api="<RESOURCE-API>",
+                method_name="<METHOD-NAME>",
+                start_time="<START_TIME>"
+                end_time="<END_TIME>"
+                additional_params="<ADDITIONAL_PARAMETERS>"
+            )
+
+            print(f"My data: {tabular_data}")
+
+        Args:
+            part_id (str): The ID of the part that owns the data.
+            resource_name (str): The name of the requested resource that captured the data.
+            resource_api (str): The API of the requested resource that captured the data.
+            method_name (str): The data capture method name.
+            start_time (datetime): Optional start time for requesting a specific range of data.
+            end_time (datetime): Optional end time for requesting a specific range of data.
+            additional_params (dict): Optional additional parameters of the resource that captured the data.
+
+        Returns:
+            List[TabularDataPoint]: The unified tabular data and metadata.
+
+        For more information, see `Data Client API <https://docs.viam.com/dev/reference/apis/data-client/#exporttabulardata>`_.
+        """
+
+        interval = CaptureInterval(start=datetime_to_timestamp(start_time), end=datetime_to_timestamp(end_time))
+        request = ExportTabularDataRequest(
+            part_id=part_id,
+            resource_name=resource_name,
+            resource_subtype=resource_api,
+            method_name=method_name,
+            interval=interval,
+            additional_parameters=dict_to_struct(additional_params),
+        )
+        response: List[ExportTabularDataResponse] = await self._data_client.ExportTabularData(request, metadata=self._metadata)
+
+        return [
+            DataClient.TabularDataPoint(
+                part_id=resp.part_id,
+                resource_name=resp.resource_name,
+                resource_api=resp.resource_subtype,
+                method_name=resp.method_name,
+                time_captured=resp.time_captured.ToDatetime(),
+                organization_id=resp.organization_id,
+                location_id=resp.location_id,
+                robot_name=resp.robot_name,
+                robot_id=resp.robot_id,
+                part_name=resp.part_name,
+                method_parameters=struct_to_dict(resp.method_parameters),
+                tags=list(resp.tags),
+                payload=struct_to_dict(resp.payload),
+            )
+            for resp in response
+        ]
+
+    async def binary_data_by_filter(
+        self,
+        filter: Optional[Filter] = None,
+        limit: Optional[int] = None,
+        sort_order: Optional[Order.ValueType] = None,
+        last: Optional[str] = None,
+        include_binary_data: bool = True,
+        count_only: bool = False,
+        include_internal_data: bool = False,
+        dest: Optional[str] = None,
+    ) -> Tuple[List[BinaryData], int, str]:
+        """Filter and download binary data. The data will be paginated into pages of ``limit`` items, and the pagination ID will be included
+        in the returned tuple as ``last``. If a destination is provided, this method saves returned data to that file,
+        overwriting any existing file content.
+
+        ::
+
+            from viam.utils import create_filter
+            from viam.proto.app.data import Filter, TagsFilter, TagsFilterType
+
+            # Get data captured from camera components
+            my_data = []
+            last = None
+            my_filter = create_filter(component_name="camera-1")
+
+            while True:
+                data, count, last = await data_client.binary_data_by_filter(
+                    my_filter, limit=1, last=last)
+                if not data:
+                    break
+                my_data.extend(data)
+
+            print(f"My data: {my_data}")
+
+            # Get untagged data from a dataset
+
+            my_untagged_data = []
+            last = None
+            tags_filter = TagsFilter(type=TagsFilterType.TAGS_FILTER_TYPE_UNTAGGED)
+            my_filter = Filter(
+                dataset_id="66db6fe7d93d1ade24cd1dc3",
+                tags_filter=tags_filter
+            )
+
+            while True:
+                data, count, last = await data_client.binary_data_by_filter(
+                    my_filter, last=last, include_binary_data=False)
+                if not data:
+                    break
+                my_untagged_data.extend(data)
+
+        Args:
+            filter (~viam.proto.app.data.Filter): Optional, specifies tabular data to retrieve. An empty filter matches all binary data.
+            limit (int): The maximum number of entries to include in a page. Defaults to 50 if unspecified.
+            sort_order (~viam.proto.app.data.Order): The desired sort order of the data.
+            last (str): Optional string indicating the object identifier of the last-returned data.
+                This object identifier is returned by calls to :meth:`binary_data_by_filter` as the ``last`` value.
+                If provided, the server will return the next data entries after the last object identifier.
+            include_binary_data (bool): Boolean specifying whether to actually include the binary file data with each retrieved file.
+                Defaults to true (that is, both the files' data and metadata are returned).
+            count_only (bool): Whether to return only the total count of entries.
+            include_internal_data (bool): Whether to return the internal data. Internal data is used for Viam-specific data ingestion,
+                like cloud SLAM. Defaults to ``False``.
+            dest (str): Optional filepath for writing retrieved data.
+
+        Returns:
+            Tuple[List[~viam.proto.app.data.BinaryData], int, str]: A tuple containing the following:
+
+                - ``data`` (*List[* :class:`~viam.proto.app.data.BinaryData` *]*): The binary data.
+                - ``count`` (*int*): The count (number of entries).
+                - ``last`` (*str*): The last-returned page ID.
+
+        For more information, see `Data Client API <https://docs.viam.com/dev/reference/apis/data-client/#binarydatabyfilter>`_.
+        """
+
+        data_request = DataRequest(filter=filter)
+        if limit:
+            data_request.limit = limit
+        if sort_order:
+            data_request.sort_order = sort_order
+        if last:
+            data_request.last = last
+        request = BinaryDataByFilterRequest(
+            data_request=data_request,
+            include_binary=include_binary_data,
+            count_only=count_only,
+            include_internal_data=include_internal_data,
+        )
+        response: BinaryDataByFilterResponse = await self._data_client.BinaryDataByFilter(request, metadata=self._metadata)
+        data = list(response.data)
+        if dest:
+            try:
+                file = open(dest, "w")
+                file.write(f"{[str(d) for d in data]}")
+                file.flush()
+            except Exception as e:
+                LOGGER.error(f"Failed to write binary data to file {dest}", exc_info=e)
+
+        return data, response.count, response.last
+
+    async def binary_data_by_ids(
+        self,
+        binary_ids: Union[List[BinaryID], List[str]],
+        dest: Optional[str] = None,
+    ) -> List[BinaryData]:
+        """Filter and download binary data.
+
+        ::
+
+            binary_metadata, count, last = await data_client.binary_data_by_filter(
+                include_binary_data=False
+            )
+
+            my_ids = []
+
+            for obj in binary_metadata:
+                my_ids.append(obj.metadata.binary_data_id)
+
+            binary_data = await data_client.binary_data_by_ids(my_ids)
+
+        Args:
+            binary_ids (Union[List[~viam.proto.app.data.BinaryID], List[str]]): Binary data ID strings specifying the desired data or
+                :class:`BinaryID` objects. Must be non-empty.
+                *DEPRECATED:* :class:`BinaryID` *is deprecated and will be removed in a future release. Instead, pass binary data IDs as a
+                list of strings.*
+            dest (str): Optional filepath for writing retrieved data.
+
+        Raises:
+            GRPCError: If no binary data ID strings or :class:`BinaryID` objects are provided.
+
+        Returns:
+            List[~viam.proto.app.data.BinaryData]: The binary data.
+
+        For more information, see `Data Client API <https://docs.viam.com/dev/reference/apis/data-client/#binarydatabyids>`_.
+        """
+        request = BinaryDataByIDsRequest()
+        if len(binary_ids) > 0 and isinstance(binary_ids[0], str):
+            binary_data_ids = cast(List[str], binary_ids)
+            request = BinaryDataByIDsRequest(binary_data_ids=binary_data_ids, include_binary=True)
+        else:
+            bin_ids = cast(List[BinaryID], binary_ids)
+            request = BinaryDataByIDsRequest(binary_ids=bin_ids, include_binary=True)
+        response: BinaryDataByIDsResponse = await self._data_client.BinaryDataByIDs(request, metadata=self._metadata)
+        if dest:
+            try:
+                file = open(dest, "w")
+                file.write(f"{response.data}")
+                file.flush()
+            except Exception as e:
+                LOGGER.error(f"Failed to write binary data to file {dest}", exc_info=e)
+        return list(response.data)
+
+    async def delete_tabular_data(self, organization_id: str, delete_older_than_days: int) -> int:
+        """Delete tabular data older than a specified number of days.
+
+        ::
+
+            tabular_data = await data_client.delete_tabular_data(
+                organization_id="<YOUR-ORG-ID>",
+                delete_older_than_days=150
+            )
+
+        Args:
+            organization_id (str): The ID of the organization to delete the data from.
+                To find your organization ID, visit the organization settings page.
+            delete_older_than_days (int): Delete data that was captured up to *this many* days ago. For example, a value of
+                10 deletes any data that was captured up to 10 days ago. A value of 0 deletes *all* existing data.
+
+        Returns:
+            int: The number of items deleted.
+
+        For more information, see `Data Client API <https://docs.viam.com/dev/reference/apis/data-client/#deletetabulardata>`_.
+        """
+        request = DeleteTabularDataRequest(organization_id=organization_id, delete_older_than_days=delete_older_than_days)
+        response: DeleteTabularDataResponse = await self._data_client.DeleteTabularData(request, metadata=self._metadata)
+        return response.deleted_count
+
+    async def delete_tabular_data_by_filter(self, filter: Optional[Filter]) -> int:
+        """Deprecated: use :meth:`delete_tabular_data` instead."""
+        raise NotImplementedError()
+
+    async def delete_binary_data_by_filter(self, filter: Optional[Filter]) -> int:
+        """Filter and delete binary data.
+
+        ::
+
+            from viam.utils import create_filter
+
+            my_filter = create_filter(component_name="left_motor", organization_ids=["<YOUR-ORG-ID>"])
+
+            res = await data_client.delete_binary_data_by_filter(my_filter)
+
+        Args:
+            filter (~viam.proto.app.data.Filter): Optional, specifies binary data to delete.
+                **CAUTION: Passing an empty** ``Filter`` **deletes all binary data!**
+                You must specify an organization ID with ``organization_ids`` when using this option.
+                To find your organization ID, visit the organization settings page.
+
+        Returns:
+            int: The number of items deleted.
+
+        For more information, see `Data Client API <https://docs.viam.com/dev/reference/apis/data-client/#deletebinarydatabyfilter>`_.
+        """
+        filter = filter if filter else Filter()
+        request = DeleteBinaryDataByFilterRequest(filter=filter)
+        response: DeleteBinaryDataByFilterResponse = await self._data_client.DeleteBinaryDataByFilter(request, metadata=self._metadata)
+        return response.deleted_count
+
+    async def delete_binary_data_by_ids(self, binary_ids: Union[List[BinaryID], List[str]]) -> int:
+        """Filter and delete binary data.
+
+        ::
+
+            from viam.proto.app.data import BinaryID
+            from viam.utils import create_filter
+
+            my_filter = create_filter(component_name="camera-1", organization_ids=["<YOUR-ORG-ID>"])
+            binary_metadata, count, last = await data_client.binary_data_by_filter(
+                filter=my_filter,
+                limit=20,
+                include_binary_data=False
+            )
+
+            my_ids = []
+
+            for obj in binary_metadata:
+                my_ids.append(
+                    obj.metadata.binary_data_id
+                )
+
+            binary_data = await data_client.delete_binary_data_by_ids(my_ids)
+
+        Args:
+            binary_ids (Union[List[~viam.proto.app.data.BinaryID], List[str]]): Binary data ID strings specifying the data to be deleted or
+                :class:`BinaryID` objects. Must be non-empty.
+                *DEPRECATED:* :class:`BinaryID` *is deprecated and will be removed in a future release. Instead, pass binary data IDs as a
+                list of strings.*
+
+        Raises:
+            GRPCError: If no binary data ID strings or :class:`BinaryID` objects are provided.
+
+        Returns:
+            int: The number of items deleted.
+
+        For more information, see `Data Client API <https://docs.viam.com/dev/reference/apis/data-client/#deletebinarydatabyids>`_.
+        """
+        request = DeleteBinaryDataByIDsRequest()
+        if len(binary_ids) > 0 and isinstance(binary_ids[0], str):
+            binary_data_ids = cast(List[str], binary_ids)
+            request = DeleteBinaryDataByIDsRequest(binary_data_ids=binary_data_ids)
+        else:
+            bin_ids = cast(List[BinaryID], binary_ids)
+            request = DeleteBinaryDataByIDsRequest(binary_ids=bin_ids)
+        response: DeleteBinaryDataByIDsResponse = await self._data_client.DeleteBinaryDataByIDs(request, metadata=self._metadata)
+        return response.deleted_count
+
+    async def add_tags_to_binary_data_by_ids(self, tags: List[str], binary_ids: Union[List[BinaryID], List[str]]) -> None:
+        """Add tags to binary data.
+
+        ::
+
+            from viam.utils import create_filter
+
+            tags = ["tag1", "tag2"]
+
+            my_filter = create_filter(component_name="camera-1", organization_ids=["<YOUR-ORG-ID>"])
+            binary_metadata, count, last = await data_client.binary_data_by_filter(
+                filter=my_filter,
+                limit=20,
+                include_binary_data=False
+            )
+
+            my_ids = []
+
+            for obj in binary_metadata:
+                my_ids.append(
+                    obj.metadata.binary_data_id
+                )
+
+            binary_data = await data_client.add_tags_to_binary_data_by_ids(tags, my_ids)
+
+        Args:
+            tags (List[str]): List of tags to add to specified binary data. Must be non-empty.
+            binary_ids (Union[List[~viam.proto.app.data.BinaryID], List[str]]): Binary data ID strings specifying the data to be tagged or
+                :class:`BinaryID` objects. Must be non-empty.
+                *DEPRECATED:* :class:`BinaryID` *is deprecated and will be removed in a future release. Instead, pass binary data IDs as a
+                list of strings.*
+
+        Raises:
+            GRPCError: If no binary data ID strings or :class:`BinaryID` objects are provided.
+
+        For more information, see `Data Client API <https://docs.viam.com/dev/reference/apis/data-client/#addtagstobinarydatabyids>`_.
+        """
+        request = AddTagsToBinaryDataByIDsRequest()
+        if len(binary_ids) > 0 and isinstance(binary_ids[0], str):
+            binary_data_ids = cast(List[str], binary_ids)
+            request = AddTagsToBinaryDataByIDsRequest(binary_data_ids=binary_data_ids, tags=tags)
+        else:
+            bin_ids = cast(List[BinaryID], binary_ids)
+            request = AddTagsToBinaryDataByIDsRequest(binary_ids=bin_ids, tags=tags)
+        await self._data_client.AddTagsToBinaryDataByIDs(request, metadata=self._metadata)
+
+    async def add_tags_to_binary_data_by_filter(self, tags: List[str], filter: Optional[Filter] = None) -> None:
+        """Add tags to binary data.
+
+        ::
+
+            from viam.utils import create_filter
+
+            my_filter = create_filter(component_name="my_camera")
+            tags = ["tag1", "tag2"]
+            await data_client.add_tags_to_binary_data_by_filter(tags, my_filter)
+
+        Args:
+            tags (List[str]): List of tags to add to specified binary data. Must be non-empty.
+            filter (~viam.proto.app.data.Filter): Specifies binary data to tag. If none is provided, tags all data.
+
+        Raises:
+            GRPCError: If no tags are provided.
+
+        For more information, see `Data Client API <https://docs.viam.com/dev/reference/apis/data-client/#addtagstobinarydatabyfilter>`_.
+        """
+        filter = filter if filter else Filter()
+        request = AddTagsToBinaryDataByFilterRequest(filter=filter, tags=tags)
+        await self._data_client.AddTagsToBinaryDataByFilter(request, metadata=self._metadata)
+
+    async def remove_tags_from_binary_data_by_ids(self, tags: List[str], binary_ids: Union[List[BinaryID], List[str]]) -> int:
+        """Remove tags from binary data by IDs.
+
+        ::
+
+            from viam.utils import create_filter
+
+            tags = ["tag1", "tag2"]
+
+            my_filter = create_filter(component_name="camera-1")
+
+            binary_metadata, count, last = await data_client.binary_data_by_filter(
+                filter=my_filter,
+                limit=50,
+                include_binary_data=False
+            )
+
+            my_ids = []
+
+            for obj in binary_metadata:
+                my_ids.append(
+                    obj.metadata.binary_data_id
+                )
+
+            binary_data = await data_client.remove_tags_from_binary_data_by_ids(
+                tags, my_ids)
+
+        Args:
+            tags (List[str]): List of tags to remove from specified binary data. Must be non-empty.
+            binary_ids (Union[List[~viam.proto.app.data.BinaryID], List[str]]): Binary data ID strings specifying the data to be untagged
+                or `BinaryID` objects. Must be non-empty.
+                *DEPRECATED:* :class:`BinaryID` *is deprecated and will be removed in a future release. Instead, pass binary data IDs as a
+                list of strings.*
+
+        Raises:
+            GRPCError: If no binary data ID strings, :class:`BinaryID` objects, or tags are provided.
+
+        Returns:
+            int: The number of tags removed.
+
+        For more information, see `Data Client API <https://docs.viam.com/dev/reference/apis/data-client/#removetagsfrombinarydatabyids>`_.
+        """
+        request = RemoveTagsFromBinaryDataByIDsRequest(tags=tags)
+        if len(binary_ids) > 0 and isinstance(binary_ids[0], str):
+            binary_data_ids = cast(List[str], binary_ids)
+            request = RemoveTagsFromBinaryDataByIDsRequest(binary_data_ids=binary_data_ids, tags=tags)
+        else:
+            bin_ids = cast(List[BinaryID], binary_ids)
+            request = RemoveTagsFromBinaryDataByIDsRequest(binary_ids=bin_ids, tags=tags)
+        response: RemoveTagsFromBinaryDataByIDsResponse = await self._data_client.RemoveTagsFromBinaryDataByIDs(
+            request, metadata=self._metadata
+        )
+        return response.deleted_count
+
+    async def remove_tags_from_binary_data_by_filter(self, tags: List[str], filter: Optional[Filter] = None) -> int:
+        """Remove tags from binary data.
+
+        ::
+
+            from viam.utils import create_filter
+
+            my_filter = create_filter(component_name="my_camera")
+            tags = ["tag1", "tag2"]
+            res = await data_client.remove_tags_from_binary_data_by_filter(tags, my_filter)
+
+        Args:
+            tags (List[str]): List of tags to remove from specified binary data.
+            filter (~viam.proto.app.data.Filter): Specifies binary data to untag. If none is provided, removes tags from all data.
+
+        Raises:
+            GRPCError: If no tags are provided.
+
+        Returns:
+            int: The number of tags removed.
+
+        For more information, see `Data Client API <https://docs.viam.com/dev/reference/apis/data-client/#removetagsfrombinarydatabyfilter>`_.
+        """
+        filter = filter if filter else Filter()
+        request = RemoveTagsFromBinaryDataByFilterRequest(filter=filter, tags=tags)
+        response: RemoveTagsFromBinaryDataByFilterResponse = await self._data_client.RemoveTagsFromBinaryDataByFilter(
+            request, metadata=self._metadata
+        )
+        return response.deleted_count
+
+    async def tags_by_filter(self, filter: Optional[Filter] = None) -> List[str]:
+        """Get a list of tags using a filter.
+
+        ::
+
+            from viam.utils import create_filter
+
+            my_filter = create_filter(component_name="my_camera")
+            tags = await data_client.tags_by_filter(my_filter)
+
+        Args:
+            filter (~viam.proto.app.data.Filter): Specifies subset ofdata to retrieve tags from. If none is provided, returns all tags.
+
+        Returns:
+            List[str]: The list of tags.
+
+        For more information, see `Data Client API <https://docs.viam.com/dev/reference/apis/data-client/#tagsbyfilter>`_.
+        """
+        filter = filter if filter else Filter()
+        request = TagsByFilterRequest(filter=filter)
+        response: TagsByFilterResponse = await self._data_client.TagsByFilter(request, metadata=self._metadata)
+        return list(response.tags)
+
+    async def add_bounding_box_to_image_by_id(
+        self,
+        binary_id: Union[BinaryID, str],
+        label: str,
+        x_min_normalized: float,
+        y_min_normalized: float,
+        x_max_normalized: float,
+        y_max_normalized: float,
+    ) -> str:
+        """Add a bounding box to an image.
+
+        ::
+
+            bbox_id = await data_client.add_bounding_box_to_image_by_id(
+                binary_id="<YOUR-BINARY-DATA-ID>",
+                label="label",
+                x_min_normalized=0,
+                y_min_normalized=.1,
+                x_max_normalized=.2,
+                y_max_normalized=.3
+            )
+
+            print(bbox_id)
+
+        Args:
+            binary_id (Union[~viam.proto.app.data.BinaryID, str]): The binary data ID or :class:`BinaryID` of the image to add the bounding
+                box to. *DEPRECATED:* :class:`BinaryID` *is deprecated and will be removed in a future release. Instead, pass binary data
+                IDs as a list of strings.*
+            label (str): A label for the bounding box.
+            x_min_normalized (float): Min X value of the bounding box normalized from 0 to 1.
+            y_min_normalized (float): Min Y value of the bounding box normalized from 0 to 1.
+            x_max_normalized (float): Max X value of the bounding box normalized from 0 to 1.
+            y_max_normalized (float): Max Y value of the bounding box normalized from 0 to 1.
+
+        Raises:
+            GRPCError: If the X or Y values are outside of the [0, 1] range.
+
+        Returns:
+            str: The bounding box ID.
+
+        For more information, see `Data Client API <https://docs.viam.com/dev/reference/apis/data-client/#addboundingboxtoimagebyid>`_.
+        """
+        request = AddBoundingBoxToImageByIDRequest()
+        if isinstance(binary_id, str):
+            request = AddBoundingBoxToImageByIDRequest(
+                binary_data_id=binary_id,
+                label=label,
+                x_max_normalized=x_max_normalized,
+                x_min_normalized=x_min_normalized,
+                y_max_normalized=y_max_normalized,
+                y_min_normalized=y_min_normalized,
+            )
+        else:
+            request = AddBoundingBoxToImageByIDRequest(
+                binary_id=binary_id,
+                label=label,
+                x_max_normalized=x_max_normalized,
+                x_min_normalized=x_min_normalized,
+                y_max_normalized=y_max_normalized,
+                y_min_normalized=y_min_normalized,
+            )
+        response: AddBoundingBoxToImageByIDResponse = await self._data_client.AddBoundingBoxToImageByID(request, metadata=self._metadata)
+        return response.bbox_id
+
+    async def remove_bounding_box_from_image_by_id(self, bbox_id: str, binary_id: Union[BinaryID, str]) -> None:
+        """Removes a bounding box from an image.
+
+        ::
+
+            await data_client.remove_bounding_box_from_image_by_id(
+            binary_id="<YOUR-BINARY-DATA-ID>",
+            bbox_id="your-bounding-box-id-to-delete"
+            )
+
+        Args:
+            bbox_id (str): The ID of the bounding box to remove.
+            binary_id (Union[~viam.proto.app.data.BinaryID, str]): The binary data ID or :class:`BinaryID` of the image to remove the
+                bounding box from.
+                *DEPRECATED:* :class:`BinaryID` *is deprecated and will be removed in a future release. Instead, pass binary data IDs as a
+                list of strings.*
+
+        For more information, see `Data Client API <https://docs.viam.com/dev/reference/apis/data-client/#removeboundingboxfromimagebyid>`_.
+        """
+        request = RemoveBoundingBoxFromImageByIDRequest()
+        if isinstance(binary_id, str):
+            request = RemoveBoundingBoxFromImageByIDRequest(binary_data_id=binary_id, bbox_id=bbox_id)
+        else:
+            request = RemoveBoundingBoxFromImageByIDRequest(binary_id=binary_id, bbox_id=bbox_id)
+
+        await self._data_client.RemoveBoundingBoxFromImageByID(request, metadata=self._metadata)
+
+    async def bounding_box_labels_by_filter(self, filter: Optional[Filter] = None) -> List[str]:
+        """Get a list of bounding box labels using a `Filter`.
+
+        ::
+
+            from viam.utils import create_filter
+
+            my_filter = create_filter(component_name="my_camera")
+            bounding_box_labels = await data_client.bounding_box_labels_by_filter(
+                my_filter)
+
+            print(bounding_box_labels)
+
+        Args:
+            filter (~viam.proto.app.data.Filter): Specifies data to retrieve bounding box labels from. If none is provided, returns labels
+            from all data.
+
+        Returns:
+            List[str]: The list of bounding box labels.
+
+        For more information, see `Data Client API <https://docs.viam.com/dev/reference/apis/data-client/#boundingboxlabelsbyfilter>`_.
+        """
+        filter = filter if filter else Filter()
+        request = BoundingBoxLabelsByFilterRequest(filter=filter)
+        response: BoundingBoxLabelsByFilterResponse = await self._data_client.BoundingBoxLabelsByFilter(request, metadata=self._metadata)
+        return list(response.labels)
+
+    async def get_database_connection(self, organization_id: str) -> str:
+        """Get a connection to access a MongoDB Atlas Data federation instance.
+
+        ::
+
+            hostname = await data_client.get_database_connection(organization_id="<YOUR-ORG-ID>")
+
+        Args:
+            organization_id (str): The ID of the organization you'd like to connect to.
+                To find your organization ID, visit the organization settings page.
+
+        Returns:
+            str: The hostname of the federated database.
+
+        For more information, see `Data Client API <https://docs.viam.com/dev/reference/apis/data-client/#getdatabaseconnection>`_.
+        """
+        request = GetDatabaseConnectionRequest(organization_id=organization_id)
+        response: GetDatabaseConnectionResponse = await self._data_client.GetDatabaseConnection(request, metadata=self._metadata)
+        return response.hostname
+
+    async def configure_database_user(self, organization_id: str, password: str) -> None:
+        """Configure a database user for the Viam organization's MongoDB Atlas Data Federation instance. It can also be used to reset the
+        password of the existing database user.
+
+        ::
+
+            await data_client.configure_database_user(
+                organization_id="<YOUR-ORG-ID>",
+                password="Your_Password@1234"
+            )
+
+        Args:
+            organization_id (str): The ID of the organization you'd like to configure a database user for.
+                To find your organization ID, visit the organization settings page.
+            password (str): The password of the user.
+
+        For more information, see `Data Client API <https://docs.viam.com/dev/reference/apis/data-client/#configuredatabaseuser>`_.
+        """
+        request = ConfigureDatabaseUserRequest(organization_id=organization_id, password=password)
+        await self._data_client.ConfigureDatabaseUser(request, metadata=self._metadata)
+
+    async def create_dataset(self, name: str, organization_id: str) -> str:
+        """Create a new dataset.
+
+        ::
+
+            dataset_id = await data_client.create_dataset(
+                name="<DATASET-NAME>",
+                organization_id="<YOUR-ORG-ID>"
+            )
+            print(dataset_id)
+
+        Args:
+            name (str): The name of the dataset being created.
+            organization_id (str): The ID of the organization where the dataset is being created.
+                To find your organization ID, visit the organization settings page.
+
+        Returns:
+            str: The dataset ID of the created dataset.
+
+        For more information, see `Data Client API <https://docs.viam.com/dev/reference/apis/data-client/#createdataset>`_.
+        """
+        request = CreateDatasetRequest(name=name, organization_id=organization_id)
+        response: CreateDatasetResponse = await self._dataset_client.CreateDataset(request, metadata=self._metadata)
+        return response.id
+
+    async def list_dataset_by_ids(self, ids: List[str]) -> Sequence[Dataset]:
+        """Get a list of datasets using their IDs.
+
+        ::
+
+            datasets = await data_client.list_dataset_by_ids(
+                ids=["<YOUR-DATASET-ID-1>, <YOUR-DATASET-ID-2>"]
+            )
+            print(datasets)
+
+        Args:
+            ids (List[str]): The IDs of the datasets that you would like to retrieve information about. To retrieve a dataset ID:
+
+                - Navigate to the **DATASETS** tab of the **DATA** page.
+                - Click on the dataset.
+                - Click the **...** menu.
+                - Select **Copy dataset ID**.
+
+        Returns:
+            Sequence[Dataset]: The list of datasets.
+
+        For more information, see `Data Client API <https://docs.viam.com/dev/reference/apis/data-client/#listdatasetsbyids>`_.
+        """
+        request = ListDatasetsByIDsRequest(ids=ids)
+        response: ListDatasetsByIDsResponse = await self._dataset_client.ListDatasetsByIDs(request, metadata=self._metadata)
+
+        return response.datasets
+
+    async def list_datasets_by_organization_id(self, organization_id: str) -> Sequence[Dataset]:
+        """Get the datasets in an organization.
+
+        ::
+
+            datasets = await data_client.list_datasets_by_organization_id(
+                organization_id="<YOUR-ORG-ID>"
+            )
+            print(datasets)
+
+        Args:
+            organization_id (str): The ID of the organization you'd like to retrieve datasets from.
+                To find your organization ID, visit the organization settings page.
+
+        Returns:
+            Sequence[Dataset]: The list of datasets in the organization.
+
+        For more information, see `Data Client API <https://docs.viam.com/dev/reference/apis/data-client/#listdatasetsbyorganizationid>`_.
+        """
+        request = ListDatasetsByOrganizationIDRequest(organization_id=organization_id)
+        response: ListDatasetsByOrganizationIDResponse = await self._dataset_client.ListDatasetsByOrganizationID(
+            request, metadata=self._metadata
+        )
+
+        return response.datasets
+
+    async def rename_dataset(self, id: str, name: str) -> None:
+        """Rename a dataset specified by the dataset ID.
+
+        ::
+
+            await data_client.rename_dataset(
+                id="<YOUR-DATASET-ID>",
+                name="MyDataset"
+            )
+
+        Args:
+            id (str): The ID of the dataset. To retrieve the dataset ID:
+
+                - Navigate to the **DATASETS** tab of the **DATA** page.
+                - Click on the dataset.
+                - Click the **...** menu.
+                - Select **Copy dataset ID**.
+            name (str): The new name of the dataset.
+
+        For more information, see `Data Client API <https://docs.viam.com/dev/reference/apis/data-client/#renamedataset>`_.
+        """
+        request = RenameDatasetRequest(id=id, name=name)
+        await self._dataset_client.RenameDataset(request, metadata=self._metadata)
+
+    async def delete_dataset(self, id: str) -> None:
+        """Delete a dataset.
+
+        ::
+
+            await data_client.delete_dataset(
+                id="<YOUR-DATASET-ID>"
+            )
+
+        Args:
+            id (str): The ID of the dataset. To retrieve the dataset ID:
+
+                    - Navigate to the **DATASETS** tab of the **DATA** page.
+                    - Click on the dataset.
+                    - Click the **...** menu.
+                    - Select **Copy dataset ID**.
+
+        For more information, see `Data Client API <https://docs.viam.com/dev/reference/apis/data-client/#deletedataset>`_.
+        """
+        request = DeleteDatasetRequest(id=id)
+        await self._dataset_client.DeleteDataset(request, metadata=self._metadata)
+
+    async def add_binary_data_to_dataset_by_ids(self, binary_ids: Union[List[BinaryID], List[str]], dataset_id: str) -> None:
+        """Add the BinaryData to the provided dataset.
+
+        This BinaryData will be tagged with the VIAM_DATASET_{id} label.
+
+        ::
+
+            binary_metadata, count, last = await data_client.binary_data_by_filter(
+                include_binary_data=False
+            )
+
+            my_binary_data_ids = []
+
+            for obj in binary_metadata:
+                my_binary_data_ids.append(
+                    obj.metadata.binary_data_id
+                    )
+
+            await data_client.add_binary_data_to_dataset_by_ids(
+                binary_ids=my_binary_data_ids,
+                dataset_id="abcd-1234xyz-8765z-123abc"
+            )
+
+        Args:
+            binary_ids (List[~viam.proto.app.data.BinaryID]): Unique identifiers for binary data to add to the dataset. To retrieve these IDs,
+                navigate to the DATA page, click on an image, and copy its Binary Data ID from the details tab.
+            dataset_id (str): The ID of the dataset to be added to.  To retrieve the dataset ID:
+
+                - Navigate to the **DATASETS** tab of the **DATA** page.
+                - Click on the dataset.
+                - Click the **...** menu.
+                - Select **Copy dataset ID**.
+
+        For more information, see `Data Client API <https://docs.viam.com/dev/reference/apis/data-client/#addbinarydatatodatasetbyids>`_.
+        """
+        request = AddBinaryDataToDatasetByIDsRequest()
+        if len(binary_ids) > 0 and isinstance(binary_ids[0], str):
+            binary_data_ids = cast(List[str], binary_ids)
+            request = AddBinaryDataToDatasetByIDsRequest(binary_data_ids=binary_data_ids, dataset_id=dataset_id)
+        else:
+            bin_ids = cast(List[BinaryID], binary_ids)
+            request = AddBinaryDataToDatasetByIDsRequest(binary_ids=bin_ids, dataset_id=dataset_id)
+        await self._data_client.AddBinaryDataToDatasetByIDs(request, metadata=self._metadata)
+
+    async def remove_binary_data_from_dataset_by_ids(self, binary_ids: Union[List[BinaryID], List[str]], dataset_id: str) -> None:
+        """Remove the BinaryData from the provided dataset.
+
+        This BinaryData will lose the VIAM_DATASET_{id} tag.
+
+        ::
+
+            binary_metadata, count, last = await data_client.binary_data_by_filter(
+                include_binary_data=False
+            )
+
+            my_binary_data_ids = []
+
+            for obj in binary_metadata:
+                my_binary_data_ids.append(
+                    obj.metadata.binary_data_id
+                )
+
+            await data_client.remove_binary_data_from_dataset_by_ids(
+                binary_ids=my_binary_data_ids,
+                dataset_id="abcd-1234xyz-8765z-123abc"
+            )
+
+        Args:
+            binary_ids (Union[List[~viam.proto.app.data.BinaryID], List[str]]): Unique identifiers for the binary data to remove from the dataset. To retrieve these IDs,
+                navigate to the DATA page, click on an image and copy its Binary Data ID from the details tab.
+                *DEPRECATED:* :class:`BinaryID` *is deprecated and will be removed in a future release. Instead, pass binary data IDs as a
+                list of strings.*
+            dataset_id (str): The ID of the dataset to be removed from. To retrieve the dataset ID:
+
+                - Navigate to the **DATASETS** tab of the **DATA** page.
+                - Click on the dataset.
+                - Click the **...** menu.
+                - Select **Copy dataset ID**.
+
+        For more information, see `Data Client API <https://docs.viam.com/dev/reference/apis/data-client/#removebinarydatafromdatasetbyids>`_.
+        """
+        request = RemoveBinaryDataFromDatasetByIDsRequest()
+        if len(binary_ids) > 0 and isinstance(binary_ids[0], str):
+            binary_data_ids = cast(List[str], binary_ids)
+            request = RemoveBinaryDataFromDatasetByIDsRequest(binary_data_ids=binary_data_ids, dataset_id=dataset_id)
+        else:
+            bin_ids = cast(List[BinaryID], binary_ids)
+            request = RemoveBinaryDataFromDatasetByIDsRequest(binary_ids=bin_ids, dataset_id=dataset_id)
+        await self._data_client.RemoveBinaryDataFromDatasetByIDs(request, metadata=self._metadata)
+
+    async def binary_data_capture_upload(
+        self,
+        binary_data: bytes,
+        part_id: str,
+        component_type: str,
+        component_name: str,
+        method_name: str,
+        file_extension: str,
+        method_parameters: Optional[Mapping[str, Any]] = None,
+        tags: Optional[List[str]] = None,
+        data_request_times: Optional[Tuple[datetime, datetime]] = None,
+    ) -> str:
+        """Upload binary sensor data.
+
+        Upload binary data collected on a robot through a specific component (for example, a motor), along with the relevant metadata.
+        Binary data can be found on the **DATA** page.
+
+        ::
+
+            time_requested = datetime(2023, 6, 5, 11)
+            time_received = datetime(2023, 6, 5, 11, 0, 3)
+
+            file_id = await data_client.binary_data_capture_upload(
+                part_id="INSERT YOUR PART ID",
+                component_type='camera',
+                component_name='my_camera',
+                method_name='GetImages',
+                method_parameters=None,
+                tags=["tag_1", "tag_2"],
+                data_request_times=[time_requested, time_received],
+                file_extension=".jpg",
+                binary_data=b"Encoded image bytes"
+            )
+
+        Args:
+            binary_data (bytes): The data to be uploaded, represented in bytes.
+            part_id (str): Part ID of the component used to capture the data.
+            component_type (str): Type of the component used to capture the data (for example, "movement_sensor").
+            component_name (str): Name of the component used to capture the data.
+            method_name (str): Name of the method used to capture the data.
+            file_extension (str): The file extension of binary data, *including the period*, for example ``.jpg``, ``.png``, ``.pcd``.
+                The backend routes the binary to its corresponding mime type based on this extension. Files with a ``.jpeg``, ``.jpg``,
+                or ``.png`` extension will appear in the **Images** tab.
+            method_parameters (Optional[Mapping[str, Any]]): Optional dictionary of method parameters. No longer in active use.
+            tags (Optional[List[str]]): Optional list of tags to allow for tag-based data filtering when retrieving data.
+            data_request_times (Optional[Tuple[datetime.datetime, datetime.datetime]]): Optional tuple containing datetime objects
+                denoting the times this data was requested ``[0]`` by the robot and received ``[1]`` from the appropriate sensor.
+
+        Raises:
+            GRPCError: If an invalid part ID is passed.
+
+        Returns:
+            str: The binary data ID of the uploaded data.
+
+        For more information, see `Data Client API <https://docs.viam.com/dev/reference/apis/data-client/#binarydatacaptureupload>`_.
+        """
+        sensor_contents = SensorData(
+            metadata=(
+                SensorMetadata(
+                    time_requested=datetime_to_timestamp(data_request_times[0]) if data_request_times else None,
+                    time_received=datetime_to_timestamp(data_request_times[1]) if data_request_times else None,
+                )
+                if data_request_times
+                else None
+            ),
+            struct=None,  # Used for tabular data.
+            binary=binary_data,
+        )
+        metadata = UploadMetadata(
+            part_id=part_id,
+            component_type=component_type,
+            component_name=component_name,
+            method_name=method_name,
+            type=DataType.DATA_TYPE_BINARY_SENSOR,
+            method_parameters=method_parameters,
+            tags=tags,
+        )
+        if file_extension:
+            metadata.file_extension = file_extension if file_extension[0] == "." else f".{file_extension}"
+        response = await self._data_capture_upload(metadata=metadata, sensor_contents=[sensor_contents])
+        return response.binary_data_id
+
+    async def tabular_data_capture_upload(
+        self,
+        tabular_data: List[Mapping[str, Any]],
+        part_id: str,
+        component_type: str,
+        component_name: str,
+        method_name: str,
+        data_request_times: List[Tuple[datetime, datetime]],
+        method_parameters: Optional[Mapping[str, Any]] = None,
+        tags: Optional[List[str]] = None,
+    ) -> str:
+        """Upload tabular sensor data.
+
+        Upload tabular data collected on a robot through a specific component (for example, a motor), along with the relevant metadata.
+        Tabular data can be found under the **Sensors** tab of the **DATA** page.
+
+        ::
+
+            from datetime import datetime
+
+            time_requested = datetime(2023, 6, 5, 11)
+            time_received = datetime(2023, 6, 5, 11, 0, 3)
+            file_id = await data_client.tabular_data_capture_upload(
+                part_id="INSERT YOUR PART ID",
+                component_type='rdk:component:movement_sensor',
+                component_name='my_movement_sensor',
+                method_name='Readings',
+                tags=["sensor_data"],
+                data_request_times=[(time_requested, time_received)],
+                tabular_data=[{
+                    'readings': {
+                        'linear_velocity': {'x': 0.5, 'y': 0.0, 'z': 0.0},
+                        'angular_velocity': {'x': 0.0, 'y': 0.0, 'z': 0.1}
+                    }
+                }]
+            )
+
+        Args:
+            tabular_data (List[Mapping[str, Any]]): List of the data to be uploaded, represented tabularly as a collection of dictionaries.
+                Must include the key ``readings`` for sensors.
+            part_id (str): Part ID of the component used to capture the data.
+            component_type (str): Type of the component used to capture the data (for example, ``rdk:component:movement_sensor``).
+            component_name (str): Name of the component used to capture the data.
+            method_name (str): Name of the method used to capture the data.
+            data_request_times (List[Tuple[datetime.datetime, datetime.datetime]]): List of tuples, each containing ``datetime`` objects
+                denoting the times this data was requested ``[0]`` by the robot and received ``[1]`` from the appropriate sensor.
+                Pass a list of tabular data and timestamps with length ``n > 1`` to upload ``n`` datapoints, all with the same metadata.
+            method_parameters (Optional[Mapping[str, Any]]): Optional dictionary of method parameters. No longer in active use.
+            tags (Optional[List[str]]): Optional list of tags to allow for tag-based data filtering when retrieving data.
+
+        Raises:
+            GRPCError: If an invalid part ID is passed.
+            ValueError: If the provided list of `Timestamp` objects has a length that does not match the length of the list of tabular
+                data.
+
+        Returns:
+            str: The file ID of the uploaded data.
+
+        For more information, see `Data Client API <https://docs.viam.com/dev/reference/apis/data-client/#tabulardatacaptureupload>`_.
+        """
+        sensor_contents = []
+        if len(data_request_times) != len(tabular_data):
+            raise ValueError("data_request_times and tabular_data lengths must be equal.")
+
+        for idx, tab in enumerate(tabular_data):
+            s = Struct()
+            s.update(tab)
+            sensor_contents.append(
+                SensorData(
+                    metadata=(
+                        SensorMetadata(
+                            time_requested=datetime_to_timestamp(data_request_times[idx][0]) if data_request_times else None,
+                            time_received=datetime_to_timestamp(data_request_times[idx][1]) if data_request_times else None,
+                        )
+                        if data_request_times[idx]
+                        else None
+                    )
+                    if data_request_times
+                    else None,
+                    struct=s,
+                )
+            )
+
+        metadata = UploadMetadata(
+            part_id=part_id,
+            component_type=component_type,
+            component_name=component_name,
+            method_name=method_name,
+            type=DataType.DATA_TYPE_TABULAR_SENSOR,
+            method_parameters=method_parameters,
+            tags=tags,
+        )
+        response = await self._data_capture_upload(metadata=metadata, sensor_contents=sensor_contents)
+        return response.file_id
+
+    async def _data_capture_upload(self, metadata: UploadMetadata, sensor_contents: List[SensorData]) -> DataCaptureUploadResponse:
+        request = DataCaptureUploadRequest(metadata=metadata, sensor_contents=sensor_contents)
+        response: DataCaptureUploadResponse = await self._data_sync_client.DataCaptureUpload(request, metadata=self._metadata)
+        return response
+
+    async def streaming_data_capture_upload(
+        self,
+        data: bytes,
+        part_id: str,
+        file_ext: str,
+        component_type: Optional[str] = None,
+        component_name: Optional[str] = None,
+        method_name: Optional[str] = None,
+        method_parameters: Optional[Mapping[str, Any]] = None,
+        data_request_times: Optional[Tuple[datetime, datetime]] = None,
+        tags: Optional[List[str]] = None,
+    ) -> str:
+        """Uploads the metadata and contents of streaming binary data.
+
+        ::
+
+            time_requested = datetime(2023, 6, 5, 11)
+            time_received = datetime(2023, 6, 5, 11, 0, 3)
+
+            file_id = await data_client.streaming_data_capture_upload(
+                data="byte-data-to-upload",
+                part_id="INSERT YOUR PART ID",
+                file_ext="png",
+                component_type='motor',
+                component_name='left_motor',
+                method_name='IsPowered',
+                data_request_times=[time_requested, time_received],
+                tags=["tag_1", "tag_2"]
+            )
+
+        Args:
+            data (bytes): The data to be uploaded.
+            part_id (str): Part ID of the resource associated with the file.
+            file_ext (str): File extension type for the data. required for determining MIME type.
+            component_type (Optional[str]): Optional type of the component associated with the file (for example, "movement_sensor").
+            component_name (Optional[str]): Optional name of the component associated with the file.
+            method_name (Optional[str]): Optional name of the method associated with the file.
+            method_parameters (Optional[str]): Optional dictionary of the method parameters. No longer in active use.
+            data_request_times (Optional[Tuple[datetime.datetime, datetime.datetime]]): Optional tuple containing datetime objects
+                denoting the times this data was requested ``[0]`` by the robot and received ``[1]`` from the appropriate sensor.
+            tags (Optional[List[str]]): Optional list of tags to allow for tag-based filtering when retrieving data.
+
+        Raises:
+            GRPCError: If an invalid part ID is passed.
+
+        Returns:
+            str: The binary data ID of the uploaded data.
+
+        For more information, see `Data Client API <https://docs.viam.com/dev/reference/apis/data-client/#streamingdatacaptureupload>`_.
+        """
+
+        upload_metadata = UploadMetadata(
+            part_id=part_id,
+            component_type=component_type if component_type else "",
+            component_name=component_name if component_name else "",
+            method_name=method_name if method_name else "",
+            method_parameters=method_parameters,
+            type=DataType.DATA_TYPE_BINARY_SENSOR,
+            file_extension=file_ext if file_ext[0] == "." else f".{file_ext}",
+            tags=tags,
+        )
+        sensor_metadata = SensorMetadata(
+            time_requested=datetime_to_timestamp(data_request_times[0]) if data_request_times else None,
+            time_received=datetime_to_timestamp(data_request_times[1]) if data_request_times else None,
+        )
+        metadata = DataCaptureUploadMetadata(upload_metadata=upload_metadata, sensor_metadata=sensor_metadata)
+        request_metadata = StreamingDataCaptureUploadRequest(metadata=metadata)
+        stream: Stream[StreamingDataCaptureUploadRequest, StreamingDataCaptureUploadResponse]
+        async with self._data_sync_client.StreamingDataCaptureUpload.open(metadata=self._metadata) as stream:
+            await stream.send_message(request_metadata)
+            await stream.send_message(StreamingDataCaptureUploadRequest(data=data), end=True)
+            response = await stream.recv_message()
+            if not response:
+                await stream.recv_trailing_metadata()  # causes us to throw appropriate gRPC error
+                raise TypeError("Response cannot be empty")
+            return response.binary_data_id
+
+    async def file_upload(
+        self,
+        part_id: str,
+        data: bytes,
+        component_type: Optional[str] = None,
+        component_name: Optional[str] = None,
+        method_name: Optional[str] = None,
+        file_name: Optional[str] = None,
+        method_parameters: Optional[Mapping[str, Any]] = None,
+        file_extension: Optional[str] = None,
+        tags: Optional[List[str]] = None,
+    ) -> str:
+        """Upload arbitrary file data.
+
+        Upload file data that may be stored on a robot along with the relevant metadata. File data can be found in the
+        **Files** tab of the **DATA** page.
+
+        ::
+
+            file_id = await data_client.file_upload(
+                data=b"Encoded image bytes",
+                part_id="INSERT YOUR PART ID",
+                tags=["tag_1", "tag_2"],
+                file_name="your-file",
+                file_extension=".txt"
+            )
+
+        Args:
+            part_id (str): Part ID of the resource associated with the file.
+            data (bytes): Bytes representing file data to upload.
+            component_type (Optional[str]): Optional type of the component associated with the file (for example, "movement_sensor").
+            component_name (Optional[str]): Optional name of the component associated with the file.
+            method_name (Optional[str]): Optional name of the method associated with the file.
+            file_name (Optional[str]): Optional name of the file. The empty string ``""`` will be assigned as the file name if one isn't
+                provided.
+            method_parameters (Optional[str]): Optional dictionary of the method parameters. No longer in active use.
+            file_extension (Optional[str]): Optional file extension. The empty string ``""`` will be assigned as the file extension if one
+                isn't provided. Files with a ``.jpeg``, ``.jpg``, or ``.png`` extension will be saved to the **Images** tab.
+            tags (Optional[List[str]]): Optional list of tags to allow for tag-based filtering when retrieving data.
+
+        Raises:
+            GRPCError: If an invalid part ID is passed.
+
+        Returns:
+            str: Binary data ID of the new file.
+
+        For more information, see `Data Client API <https://docs.viam.com/dev/reference/apis/data-client/#fileupload>`_.
+        """
+        metadata = UploadMetadata(
+            part_id=part_id,
+            component_type=component_type if component_type else "",
+            component_name=component_name if component_name else "",
+            method_name=method_name if method_name else "",
+            type=DataType.DATA_TYPE_FILE,
+            file_name=file_name if file_name else "",
+            method_parameters=method_parameters,
+            file_extension=file_extension if file_extension else "",
+            tags=tags,
+        )
+        response: FileUploadResponse = await self._file_upload(metadata=metadata, file_contents=FileData(data=data))
+        return response.binary_data_id
+
+    async def file_upload_from_path(
+        self,
+        filepath: str,
+        part_id: str,
+        component_type: Optional[str] = None,
+        component_name: Optional[str] = None,
+        method_name: Optional[str] = None,
+        method_parameters: Optional[Mapping[str, Any]] = None,
+        tags: Optional[List[str]] = None,
+    ) -> str:
+        """Upload arbitrary file data.
+
+        Upload file data that may be stored on a robot along with the relevant metadata. File data can be found in the
+        **Files** tab of the **DATA** page.
+
+        ::
+
+            file_id = await data_client.file_upload_from_path(
+                part_id="INSERT YOUR PART ID",
+                tags=["tag_1", "tag_2"],
+                filepath="/Users/<your-username>/<your-directory>/<your-file.txt>"
+            )
+
+        Args:
+            filepath (str): Absolute filepath of file to be uploaded.
+            part_id (str): Part ID of the component associated with the file.
+            component_type (Optional[str]): Optional type of the component associated with the file (for example, "movement_sensor").
+            component_name (Optional[str]): Optional name of the component associated with the file.
+            method_name (Optional[str]): Optional name of the method associated with the file.
+            method_parameters (Optional[str]): Optional dictionary of the method parameters. No longer in active use.
+            tags (Optional[List[str]]): Optional list of tags to allow for tag-based filtering when retrieving data.
+
+
+        Raises:
+            GRPCError: If an invalid part ID is passed.
+            FileNotFoundError: If the provided filepath is not found.
+
+        Returns:
+            str: Binary data ID of the new file.
+
+        For more information, see `Data Client API <https://docs.viam.com/dev/reference/apis/data-client/#fileuploadfrompath>`_.
+        """
+        path = Path(filepath)
+        file_name = path.stem
+        file_extension = path.suffix if path.suffix != "" else None
+        f = open(filepath, "rb")
+        data = f.read()
+        f.close()
+
+        metadata = UploadMetadata(
+            part_id=part_id,
+            component_type=component_type if component_type else "",
+            component_name=component_name if component_name else "",
+            method_name=method_name if method_name else "",
+            type=DataType.DATA_TYPE_FILE,
+            file_name=file_name,
+            method_parameters=method_parameters,
+            file_extension=file_extension if file_extension else "",
+            tags=tags,
+        )
+        response: FileUploadResponse = await self._file_upload(metadata=metadata, file_contents=FileData(data=data if data else bytes()))
+        return response.binary_data_id
+
+    async def _file_upload(self, metadata: UploadMetadata, file_contents: FileData) -> FileUploadResponse:
+        request_metadata = FileUploadRequest(metadata=metadata)
+        request_file_contents = FileUploadRequest(file_contents=file_contents)
+        stream: Stream[FileUploadRequest, FileUploadResponse]
+        async with self._data_sync_client.FileUpload.open(metadata=self._metadata) as stream:
+            await stream.send_message(request_metadata)
+            await stream.send_message(request_file_contents, end=True)
+            response = await stream.recv_message()
+            if not response:
+                await stream.recv_trailing_metadata()  # causes us to throw appropriate gRPC error.
+                raise TypeError("Response cannot be empty")
+            return response
+
+    async def get_data_pipeline(self, id: str) -> DataPipeline:
+        """Get a data pipeline by its ID.
+
+        ::
+
+            data_pipeline = await data_client.get_data_pipeline(id="<YOUR-DATA-PIPELINE-ID>")
+
+        Args:
+            id (str): The ID of the data pipeline to get.
+
+        Returns:
+            DataPipeline: The data pipeline with the given ID.
+        """
+        request = GetDataPipelineRequest(id=id)
+        response: GetDataPipelineResponse = await self._data_pipelines_client.GetDataPipeline(request, metadata=self._metadata)
+        return DataClient.DataPipeline.from_proto(response.data_pipeline)
+
+    async def list_data_pipelines(self, organization_id: str) -> List[DataPipeline]:
+        """List all of the data pipelines for an organization.
+
+        ::
+
+            data_pipelines = await data_client.list_data_pipelines(organization_id="<YOUR-ORGANIZATION-ID>")
+
+        Args:
+            organization_id (str): The ID of the organization that owns the pipelines.
+                You can obtain your organization ID from the organization settings page.
+
+        Returns:
+            List[DataPipeline]: A list of all of the data pipelines for the given organization.
+        """
+        request = ListDataPipelinesRequest(organization_id=organization_id)
+        response: ListDataPipelinesResponse = await self._data_pipelines_client.ListDataPipelines(request, metadata=self._metadata)
+        return [DataClient.DataPipeline.from_proto(pipeline) for pipeline in response.data_pipelines]
+
+    async def create_data_pipeline(
+        self,
+        organization_id: str,
+        name: str,
+        mql_binary: List[Dict[str, Any]],
+        schedule: str,
+        enable_backfill: bool,
+        data_source_type: TabularDataSourceType.ValueType = TabularDataSourceType.TABULAR_DATA_SOURCE_TYPE_STANDARD,
+    ) -> str:
+        """Create a new data pipeline.
+
+        ::
+
+            data_pipeline_id = await data_client.create_data_pipeline(
+                organization_id="<YOUR-ORGANIZATION-ID>",
+                name="<YOUR-PIPELINE-NAME>",
+                mql_binary=[<YOUR-MQL-PIPELINE-AGGREGATION>],
+                schedule="<YOUR-SCHEDULE>",
+                data_source_type=TabularDataSourceType.TABULAR_DATA_SOURCE_TYPE_STANDARD,
+            )
+
+        Args:
+            organization_id (str): The ID of the organization that will own the pipeline.
+                You can obtain your organization ID from the organization settings page.
+            name (str): The name of the pipeline.
+            mql_binary (List[Dict[str, Any]]):The MQL pipeline to run, as a list of MongoDB aggregation pipeline stages.
+            schedule (str): A cron expression representing the expected execution schedule in UTC (note this also
+                defines the input time window; an hourly schedule would process 1 hour of data at a time).
+            enable_backfill (bool):  When true, pipeline runs will be scheduled for the organization's past data.
+            data_source_type (TabularDataSourceType): The type of data source to use for the pipeline.
+                Defaults to TabularDataSourceType.TABULAR_DATA_SOURCE_TYPE_STANDARD.
+
+        Returns:
+            str: The ID of the newly created pipeline.
+        """
+        binary: List[bytes] = [bson.encode(query) for query in mql_binary]
+        request = CreateDataPipelineRequest(
+            organization_id=organization_id,
+            name=name,
+            mql_binary=binary,
+            schedule=schedule,
+            enable_backfill=enable_backfill,
+            data_source_type=data_source_type,
+        )
+        response: CreateDataPipelineResponse = await self._data_pipelines_client.CreateDataPipeline(request, metadata=self._metadata)
+        return response.id
+
+    async def delete_data_pipeline(self, id: str) -> None:
+        """Delete a data pipeline by its ID.
+
+        ::
+
+            await data_client.delete_data_pipeline(id="<YOUR-DATA-PIPELINE-ID>")
+
+        Args:
+            id (str): The ID of the data pipeline to delete.
+        """
+        request = DeleteDataPipelineRequest(id=id)
+        await self._data_pipelines_client.DeleteDataPipeline(request, metadata=self._metadata)
+
+    async def list_data_pipeline_runs(self, id: str, page_size: int = 10) -> DataPipelineRunsPage:
+        """List all of the data pipeline runs for a data pipeline.
+
+        ::
+
+            data_pipeline_runs = await data_client.list_data_pipeline_runs(id="<YOUR-DATA-PIPELINE-ID>")
+            while len(data_pipeline_runs.runs) > 0:
+                data_pipeline_runs = await data_pipeline_runs.next_page()
+
+        Args:
+            id (str): The ID of the pipeline to list runs for
+            page_size (int): The number of runs to return per page. Defaults to 10.
+
+        Returns:
+            DataPipelineRunsPage: A page of data pipeline runs with pagination support
+        """
+        return await self._list_data_pipeline_runs(id, page_size)
+
+    async def _list_data_pipeline_runs(self, id: str, page_size: int, page_token: str = "") -> DataPipelineRunsPage:
+        """Internal method to list data pipeline runs with pagination.
+
+        Args:
+            id (str): The ID of the pipeline to list runs for
+            page_size (int): The number of runs to return per page
+            page_token (str): The token to use to get the next page of results
+
+        Returns:
+            DataPipelineRunsPage: A page of data pipeline runs with pagination support
+        """
+        request = ListDataPipelineRunsRequest(id=id, page_size=page_size, page_token=page_token)
+        response: ListDataPipelineRunsResponse = await self._data_pipelines_client.ListDataPipelineRuns(request, metadata=self._metadata)
+        return DataClient.DataPipelineRunsPage.from_proto(response, self, page_size)
+
+    @staticmethod
+    def create_filter(
+        component_name: Optional[str] = None,
+        component_type: Optional[str] = None,
+        method: Optional[str] = None,
+        robot_name: Optional[str] = None,
+        robot_id: Optional[str] = None,
+        part_name: Optional[str] = None,
+        part_id: Optional[str] = None,
+        location_ids: Optional[List[str]] = None,
+        organization_ids: Optional[List[str]] = None,
+        mime_type: Optional[List[str]] = None,
+        start_time: Optional[datetime] = None,
+        end_time: Optional[datetime] = None,
+        tags: Optional[List[str]] = None,
+        bbox_labels: Optional[List[str]] = None,
+        dataset_id: Optional[str] = None,
+    ) -> Filter:
+        warnings.warn("DataClient.create_filter is deprecated. Use utils.create_filter instead.", DeprecationWarning, stacklevel=2)
+        return create_filter(
+            component_name,
+            component_type,
+            method,
+            robot_name,
+            robot_id,
+            part_name,
+            part_id,
+            location_ids,
+            organization_ids,
+            mime_type,
+            start_time,
+            end_time,
+            tags,
+            bbox_labels,
+            dataset_id,
+        )

--- a/ai_updater/tests/scenario-5/proto_diff.txt
+++ b/ai_updater/tests/scenario-5/proto_diff.txt
@@ -1,0 +1,99 @@
+diff --git a/src/viam/gen/app/datasync/v1/data_sync_pb2.py b/src/viam/gen/app/datasync/v1/data_sync_pb2.py
+index 52c072635..ade436506 100644
+--- a/src/viam/gen/app/datasync/v1/data_sync_pb2.py
++++ b/src/viam/gen/app/datasync/v1/data_sync_pb2.py
+@@ -11,7 +11,7 @@ from google.api import annotations_pb2 as google_dot_api_dot_annotations__pb2
+ from google.protobuf import any_pb2 as google_dot_protobuf_dot_any__pb2
+ from google.protobuf import struct_pb2 as google_dot_protobuf_dot_struct__pb2
+ from google.protobuf import timestamp_pb2 as google_dot_protobuf_dot_timestamp__pb2
+-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x1fapp/datasync/v1/data_sync.proto\x12\x14viam.app.datasync.v1\x1a\x16app/data/v1/data.proto\x1a\x1cgoogle/api/annotations.proto\x1a\x19google/protobuf/any.proto\x1a\x1cgoogle/protobuf/struct.proto\x1a\x1fgoogle/protobuf/timestamp.proto"\xa7\x01\n\x18DataCaptureUploadRequest\x12@\n\x08metadata\x18\x01 \x01(\x0b2$.viam.app.datasync.v1.UploadMetadataR\x08metadata\x12I\n\x0fsensor_contents\x18\x02 \x03(\x0b2 .viam.app.datasync.v1.SensorDataR\x0esensorContents"Z\n\x19DataCaptureUploadResponse\x12\x17\n\x07file_id\x18\x01 \x01(\tR\x06fileId\x12$\n\x0ebinary_data_id\x18\x02 \x01(\tR\x0cbinaryDataId"\xaf\x01\n\x11FileUploadRequest\x12B\n\x08metadata\x18\x01 \x01(\x0b2$.viam.app.datasync.v1.UploadMetadataH\x00R\x08metadata\x12E\n\rfile_contents\x18\x02 \x01(\x0b2\x1e.viam.app.datasync.v1.FileDataH\x00R\x0cfileContentsB\x0f\n\rupload_packet"W\n\x12FileUploadResponse\x12\x1b\n\x07file_id\x18\x01 \x01(\tB\x02\x18\x01R\x06fileId\x12$\n\x0ebinary_data_id\x18\x02 \x01(\tR\x0cbinaryDataId"\x99\x01\n!StreamingDataCaptureUploadRequest\x12M\n\x08metadata\x18\x01 \x01(\x0b2/.viam.app.datasync.v1.DataCaptureUploadMetadataH\x00R\x08metadata\x12\x14\n\x04data\x18\x02 \x01(\x0cH\x00R\x04dataB\x0f\n\rupload_packet"g\n"StreamingDataCaptureUploadResponse\x12\x1b\n\x07file_id\x18\x01 \x01(\tB\x02\x18\x01R\x06fileId\x12$\n\x0ebinary_data_id\x18\x02 \x01(\tR\x0cbinaryDataId"\x92\x02\n\x0eSensorMetadata\x12A\n\x0etime_requested\x18\x01 \x01(\x0b2\x1a.google.protobuf.TimestampR\rtimeRequested\x12?\n\rtime_received\x18\x02 \x01(\x0b2\x1a.google.protobuf.TimestampR\x0ctimeReceived\x12;\n\tmime_type\x18\x03 \x01(\x0e2\x1e.viam.app.datasync.v1.MimeTypeR\x08mimeType\x12?\n\x0bannotations\x18\x04 \x01(\x0b2\x1d.viam.app.data.v1.AnnotationsR\x0bannotations"\xa3\x01\n\nSensorData\x12@\n\x08metadata\x18\x01 \x01(\x0b2$.viam.app.datasync.v1.SensorMetadataR\x08metadata\x121\n\x06struct\x18\x02 \x01(\x0b2\x17.google.protobuf.StructH\x00R\x06struct\x12\x18\n\x06binary\x18\x03 \x01(\x0cH\x00R\x06binaryB\x06\n\x04data"\x1e\n\x08FileData\x12\x12\n\x04data\x18\x01 \x01(\x0cR\x04data"\x91\x04\n\x0eUploadMetadata\x12\x17\n\x07part_id\x18\x01 \x01(\tR\x06partId\x12%\n\x0ecomponent_type\x18\x02 \x01(\tR\rcomponentType\x12%\n\x0ecomponent_name\x18\x03 \x01(\tR\rcomponentName\x12\x1f\n\x0bmethod_name\x18\x05 \x01(\tR\nmethodName\x122\n\x04type\x18\x06 \x01(\x0e2\x1e.viam.app.datasync.v1.DataTypeR\x04type\x12\x1b\n\tfile_name\x18\x07 \x01(\tR\x08fileName\x12g\n\x11method_parameters\x18\x08 \x03(\x0b2:.viam.app.datasync.v1.UploadMetadata.MethodParametersEntryR\x10methodParameters\x12%\n\x0efile_extension\x18\t \x01(\tR\rfileExtension\x12\x12\n\x04tags\x18\n \x03(\tR\x04tags\x1aY\n\x15MethodParametersEntry\x12\x10\n\x03key\x18\x01 \x01(\tR\x03key\x12*\n\x05value\x18\x02 \x01(\x0b2\x14.google.protobuf.AnyR\x05value:\x028\x01J\x04\x08\x04\x10\x05J\x04\x08\x0b\x10\x0cR\x0fcomponent_modelR\nsession_id"q\n\x0fCaptureInterval\x120\n\x05start\x18\x01 \x01(\x0b2\x1a.google.protobuf.TimestampR\x05start\x12,\n\x03end\x18\x02 \x01(\x0b2\x1a.google.protobuf.TimestampR\x03end"\xe5\x03\n\x13DataCaptureMetadata\x12%\n\x0ecomponent_type\x18\x01 \x01(\tR\rcomponentType\x12%\n\x0ecomponent_name\x18\x02 \x01(\tR\rcomponentName\x12\x1f\n\x0bmethod_name\x18\x04 \x01(\tR\nmethodName\x122\n\x04type\x18\x05 \x01(\x0e2\x1e.viam.app.datasync.v1.DataTypeR\x04type\x12l\n\x11method_parameters\x18\x06 \x03(\x0b2?.viam.app.datasync.v1.DataCaptureMetadata.MethodParametersEntryR\x10methodParameters\x12%\n\x0efile_extension\x18\x07 \x01(\tR\rfileExtension\x12\x12\n\x04tags\x18\x08 \x03(\tR\x04tags\x1aY\n\x15MethodParametersEntry\x12\x10\n\x03key\x18\x01 \x01(\tR\x03key\x12*\n\x05value\x18\x02 \x01(\x0b2\x14.google.protobuf.AnyR\x05value:\x028\x01J\x04\x08\x03\x10\x04J\x04\x08\t\x10\nR\x0fcomponent_modelR\nsession_id"\xb9\x01\n\x19DataCaptureUploadMetadata\x12M\n\x0fupload_metadata\x18\x01 \x01(\x0b2$.viam.app.datasync.v1.UploadMetadataR\x0euploadMetadata\x12M\n\x0fsensor_metadata\x18\x02 \x01(\x0b2$.viam.app.datasync.v1.SensorMetadataR\x0esensorMetadata*w\n\x08MimeType\x12\x19\n\x15MIME_TYPE_UNSPECIFIED\x10\x00\x12\x18\n\x14MIME_TYPE_IMAGE_JPEG\x10\x01\x12\x17\n\x13MIME_TYPE_IMAGE_PNG\x10\x02\x12\x1d\n\x19MIME_TYPE_APPLICATION_PCD\x10\x03*t\n\x08DataType\x12\x19\n\x15DATA_TYPE_UNSPECIFIED\x10\x00\x12\x1b\n\x17DATA_TYPE_BINARY_SENSOR\x10\x01\x12\x1c\n\x18DATA_TYPE_TABULAR_SENSOR\x10\x02\x12\x12\n\x0eDATA_TYPE_FILE\x10\x032\x80\x04\n\x0fDataSyncService\x12\x9e\x01\n\x11DataCaptureUpload\x12..viam.app.datasync.v1.DataCaptureUploadRequest\x1a/.viam.app.datasync.v1.DataCaptureUploadResponse"(\x82\xd3\xe4\x93\x02"" /datasync/v1/data_capture_upload\x12\x83\x01\n\nFileUpload\x12\'.viam.app.datasync.v1.FileUploadRequest\x1a(.viam.app.datasync.v1.FileUploadResponse" \x82\xd3\xe4\x93\x02\x1a"\x18/datasync/v1/file_upload(\x01\x12\xc5\x01\n\x1aStreamingDataCaptureUpload\x127.viam.app.datasync.v1.StreamingDataCaptureUploadRequest\x1a8.viam.app.datasync.v1.StreamingDataCaptureUploadResponse"2\x82\xd3\xe4\x93\x02,"*/datasync/v1/streaming_data_capture_upload(\x01B!Z\x1fgo.viam.com/api/app/datasync/v1b\x06proto3')
++DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x1fapp/datasync/v1/data_sync.proto\x12\x14viam.app.datasync.v1\x1a\x16app/data/v1/data.proto\x1a\x1cgoogle/api/annotations.proto\x1a\x19google/protobuf/any.proto\x1a\x1cgoogle/protobuf/struct.proto\x1a\x1fgoogle/protobuf/timestamp.proto"\xa7\x01\n\x18DataCaptureUploadRequest\x12@\n\x08metadata\x18\x01 \x01(\x0b2$.viam.app.datasync.v1.UploadMetadataR\x08metadata\x12I\n\x0fsensor_contents\x18\x02 \x03(\x0b2 .viam.app.datasync.v1.SensorDataR\x0esensorContents"Z\n\x19DataCaptureUploadResponse\x12\x17\n\x07file_id\x18\x01 \x01(\tR\x06fileId\x12$\n\x0ebinary_data_id\x18\x02 \x01(\tR\x0cbinaryDataId"\xaf\x01\n\x11FileUploadRequest\x12B\n\x08metadata\x18\x01 \x01(\x0b2$.viam.app.datasync.v1.UploadMetadataH\x00R\x08metadata\x12E\n\rfile_contents\x18\x02 \x01(\x0b2\x1e.viam.app.datasync.v1.FileDataH\x00R\x0cfileContentsB\x0f\n\rupload_packet"W\n\x12FileUploadResponse\x12\x1b\n\x07file_id\x18\x01 \x01(\tB\x02\x18\x01R\x06fileId\x12$\n\x0ebinary_data_id\x18\x02 \x01(\tR\x0cbinaryDataId"\x99\x01\n!StreamingDataCaptureUploadRequest\x12M\n\x08metadata\x18\x01 \x01(\x0b2/.viam.app.datasync.v1.DataCaptureUploadMetadataH\x00R\x08metadata\x12\x14\n\x04data\x18\x02 \x01(\x0cH\x00R\x04dataB\x0f\n\rupload_packet"g\n"StreamingDataCaptureUploadResponse\x12\x1b\n\x07file_id\x18\x01 \x01(\tB\x02\x18\x01R\x06fileId\x12$\n\x0ebinary_data_id\x18\x02 \x01(\tR\x0cbinaryDataId"\x92\x02\n\x0eSensorMetadata\x12A\n\x0etime_requested\x18\x01 \x01(\x0b2\x1a.google.protobuf.TimestampR\rtimeRequested\x12?\n\rtime_received\x18\x02 \x01(\x0b2\x1a.google.protobuf.TimestampR\x0ctimeReceived\x12;\n\tmime_type\x18\x03 \x01(\x0e2\x1e.viam.app.datasync.v1.MimeTypeR\x08mimeType\x12?\n\x0bannotations\x18\x04 \x01(\x0b2\x1d.viam.app.data.v1.AnnotationsR\x0bannotations"\xa3\x01\n\nSensorData\x12@\n\x08metadata\x18\x01 \x01(\x0b2$.viam.app.datasync.v1.SensorMetadataR\x08metadata\x121\n\x06struct\x18\x02 \x01(\x0b2\x17.google.protobuf.StructH\x00R\x06struct\x12\x18\n\x06binary\x18\x03 \x01(\x0cH\x00R\x06binaryB\x06\n\x04data"\x1e\n\x08FileData\x12\x12\n\x04data\x18\x01 \x01(\x0cR\x04data"\xb2\x04\n\x0eUploadMetadata\x12\x17\n\x07part_id\x18\x01 \x01(\tR\x06partId\x12%\n\x0ecomponent_type\x18\x02 \x01(\tR\rcomponentType\x12%\n\x0ecomponent_name\x18\x03 \x01(\tR\rcomponentName\x12\x1f\n\x0bmethod_name\x18\x05 \x01(\tR\nmethodName\x122\n\x04type\x18\x06 \x01(\x0e2\x1e.viam.app.datasync.v1.DataTypeR\x04type\x12\x1b\n\tfile_name\x18\x07 \x01(\tR\x08fileName\x12g\n\x11method_parameters\x18\x08 \x03(\x0b2:.viam.app.datasync.v1.UploadMetadata.MethodParametersEntryR\x10methodParameters\x12%\n\x0efile_extension\x18\t \x01(\tR\rfileExtension\x12\x12\n\x04tags\x18\n \x03(\tR\x04tags\x12\x1f\n\x0bdataset_ids\x18\x0c \x03(\tR\ndatasetIds\x1aY\n\x15MethodParametersEntry\x12\x10\n\x03key\x18\x01 \x01(\tR\x03key\x12*\n\x05value\x18\x02 \x01(\x0b2\x14.google.protobuf.AnyR\x05value:\x028\x01J\x04\x08\x04\x10\x05J\x04\x08\x0b\x10\x0cR\x0fcomponent_modelR\nsession_id"q\n\x0fCaptureInterval\x120\n\x05start\x18\x01 \x01(\x0b2\x1a.google.protobuf.TimestampR\x05start\x12,\n\x03end\x18\x02 \x01(\x0b2\x1a.google.protobuf.TimestampR\x03end"\xe5\x03\n\x13DataCaptureMetadata\x12%\n\x0ecomponent_type\x18\x01 \x01(\tR\rcomponentType\x12%\n\x0ecomponent_name\x18\x02 \x01(\tR\rcomponentName\x12\x1f\n\x0bmethod_name\x18\x04 \x01(\tR\nmethodName\x122\n\x04type\x18\x05 \x01(\x0e2\x1e.viam.app.datasync.v1.DataTypeR\x04type\x12l\n\x11method_parameters\x18\x06 \x03(\x0b2?.viam.app.datasync.v1.DataCaptureMetadata.MethodParametersEntryR\x10methodParameters\x12%\n\x0efile_extension\x18\x07 \x01(\tR\rfileExtension\x12\x12\n\x04tags\x18\x08 \x03(\tR\x04tags\x1aY\n\x15MethodParametersEntry\x12\x10\n\x03key\x18\x01 \x01(\tR\x03key\x12*\n\x05value\x18\x02 \x01(\x0b2\x14.google.protobuf.AnyR\x05value:\x028\x01J\x04\x08\x03\x10\x04J\x04\x08\t\x10\nR\x0fcomponent_modelR\nsession_id"\xb9\x01\n\x19DataCaptureUploadMetadata\x12M\n\x0fupload_metadata\x18\x01 \x01(\x0b2$.viam.app.datasync.v1.UploadMetadataR\x0euploadMetadata\x12M\n\x0fsensor_metadata\x18\x02 \x01(\x0b2$.viam.app.datasync.v1.SensorMetadataR\x0esensorMetadata*w\n\x08MimeType\x12\x19\n\x15MIME_TYPE_UNSPECIFIED\x10\x00\x12\x18\n\x14MIME_TYPE_IMAGE_JPEG\x10\x01\x12\x17\n\x13MIME_TYPE_IMAGE_PNG\x10\x02\x12\x1d\n\x19MIME_TYPE_APPLICATION_PCD\x10\x03*t\n\x08DataType\x12\x19\n\x15DATA_TYPE_UNSPECIFIED\x10\x00\x12\x1b\n\x17DATA_TYPE_BINARY_SENSOR\x10\x01\x12\x1c\n\x18DATA_TYPE_TABULAR_SENSOR\x10\x02\x12\x12\n\x0eDATA_TYPE_FILE\x10\x032\x80\x04\n\x0fDataSyncService\x12\x9e\x01\n\x11DataCaptureUpload\x12..viam.app.datasync.v1.DataCaptureUploadRequest\x1a/.viam.app.datasync.v1.DataCaptureUploadResponse"(\x82\xd3\xe4\x93\x02"" /datasync/v1/data_capture_upload\x12\x83\x01\n\nFileUpload\x12\'.viam.app.datasync.v1.FileUploadRequest\x1a(.viam.app.datasync.v1.FileUploadResponse" \x82\xd3\xe4\x93\x02\x1a"\x18/datasync/v1/file_upload(\x01\x12\xc5\x01\n\x1aStreamingDataCaptureUpload\x127.viam.app.datasync.v1.StreamingDataCaptureUploadRequest\x1a8.viam.app.datasync.v1.StreamingDataCaptureUploadResponse"2\x82\xd3\xe4\x93\x02,"*/datasync/v1/streaming_data_capture_upload(\x01B!Z\x1fgo.viam.com/api/app/datasync/v1b\x06proto3')
+ _globals = globals()
+ _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
+ _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'app.datasync.v1.data_sync_pb2', _globals)
+@@ -32,10 +32,10 @@ if not _descriptor._USE_C_DESCRIPTORS:
+     _globals['_DATASYNCSERVICE'].methods_by_name['FileUpload']._serialized_options = b'\x82\xd3\xe4\x93\x02\x1a"\x18/datasync/v1/file_upload'
+     _globals['_DATASYNCSERVICE'].methods_by_name['StreamingDataCaptureUpload']._loaded_options = None
+     _globals['_DATASYNCSERVICE'].methods_by_name['StreamingDataCaptureUpload']._serialized_options = b'\x82\xd3\xe4\x93\x02,"*/datasync/v1/streaming_data_capture_upload'
+-    _globals['_MIMETYPE']._serialized_start = 2789
+-    _globals['_MIMETYPE']._serialized_end = 2908
+-    _globals['_DATATYPE']._serialized_start = 2910
+-    _globals['_DATATYPE']._serialized_end = 3026
++    _globals['_MIMETYPE']._serialized_start = 2822
++    _globals['_MIMETYPE']._serialized_end = 2941
++    _globals['_DATATYPE']._serialized_start = 2943
++    _globals['_DATATYPE']._serialized_end = 3059
+     _globals['_DATACAPTUREUPLOADREQUEST']._serialized_start = 202
+     _globals['_DATACAPTUREUPLOADREQUEST']._serialized_end = 369
+     _globals['_DATACAPTUREUPLOADRESPONSE']._serialized_start = 371
+@@ -55,16 +55,16 @@ if not _descriptor._USE_C_DESCRIPTORS:
+     _globals['_FILEDATA']._serialized_start = 1434
+     _globals['_FILEDATA']._serialized_end = 1464
+     _globals['_UPLOADMETADATA']._serialized_start = 1467
+-    _globals['_UPLOADMETADATA']._serialized_end = 1996
+-    _globals['_UPLOADMETADATA_METHODPARAMETERSENTRY']._serialized_start = 1866
+-    _globals['_UPLOADMETADATA_METHODPARAMETERSENTRY']._serialized_end = 1955
+-    _globals['_CAPTUREINTERVAL']._serialized_start = 1998
+-    _globals['_CAPTUREINTERVAL']._serialized_end = 2111
+-    _globals['_DATACAPTUREMETADATA']._serialized_start = 2114
+-    _globals['_DATACAPTUREMETADATA']._serialized_end = 2599
+-    _globals['_DATACAPTUREMETADATA_METHODPARAMETERSENTRY']._serialized_start = 1866
+-    _globals['_DATACAPTUREMETADATA_METHODPARAMETERSENTRY']._serialized_end = 1955
+-    _globals['_DATACAPTUREUPLOADMETADATA']._serialized_start = 2602
+-    _globals['_DATACAPTUREUPLOADMETADATA']._serialized_end = 2787
+-    _globals['_DATASYNCSERVICE']._serialized_start = 3029
+-    _globals['_DATASYNCSERVICE']._serialized_end = 3541
+\ No newline at end of file
++    _globals['_UPLOADMETADATA']._serialized_end = 2029
++    _globals['_UPLOADMETADATA_METHODPARAMETERSENTRY']._serialized_start = 1899
++    _globals['_UPLOADMETADATA_METHODPARAMETERSENTRY']._serialized_end = 1988
++    _globals['_CAPTUREINTERVAL']._serialized_start = 2031
++    _globals['_CAPTUREINTERVAL']._serialized_end = 2144
++    _globals['_DATACAPTUREMETADATA']._serialized_start = 2147
++    _globals['_DATACAPTUREMETADATA']._serialized_end = 2632
++    _globals['_DATACAPTUREMETADATA_METHODPARAMETERSENTRY']._serialized_start = 1899
++    _globals['_DATACAPTUREMETADATA_METHODPARAMETERSENTRY']._serialized_end = 1988
++    _globals['_DATACAPTUREUPLOADMETADATA']._serialized_start = 2635
++    _globals['_DATACAPTUREUPLOADMETADATA']._serialized_end = 2820
++    _globals['_DATASYNCSERVICE']._serialized_start = 3062
++    _globals['_DATASYNCSERVICE']._serialized_end = 3574
+\ No newline at end of file
+diff --git a/src/viam/gen/app/datasync/v1/data_sync_pb2.pyi b/src/viam/gen/app/datasync/v1/data_sync_pb2.pyi
+index 0adab7705..2c6667146 100644
+--- a/src/viam/gen/app/datasync/v1/data_sync_pb2.pyi
++++ b/src/viam/gen/app/datasync/v1/data_sync_pb2.pyi
+@@ -299,6 +299,7 @@ class UploadMetadata(google.protobuf.message.Message):
+     METHOD_PARAMETERS_FIELD_NUMBER: builtins.int
+     FILE_EXTENSION_FIELD_NUMBER: builtins.int
+     TAGS_FIELD_NUMBER: builtins.int
++    DATASET_IDS_FIELD_NUMBER: builtins.int
+     part_id: builtins.str
+     component_type: builtins.str
+     component_name: builtins.str
+@@ -315,10 +316,14 @@ class UploadMetadata(google.protobuf.message.Message):
+     def tags(self) -> google.protobuf.internal.containers.RepeatedScalarFieldContainer[builtins.str]:
+         ...
+ 
+-    def __init__(self, *, part_id: builtins.str=..., component_type: builtins.str=..., component_name: builtins.str=..., method_name: builtins.str=..., type: global___DataType.ValueType=..., file_name: builtins.str=..., method_parameters: collections.abc.Mapping[builtins.str, google.protobuf.any_pb2.Any] | None=..., file_extension: builtins.str=..., tags: collections.abc.Iterable[builtins.str] | None=...) -> None:
++    @property
++    def dataset_ids(self) -> google.protobuf.internal.containers.RepeatedScalarFieldContainer[builtins.str]:
++        ...
++
++    def __init__(self, *, part_id: builtins.str=..., component_type: builtins.str=..., component_name: builtins.str=..., method_name: builtins.str=..., type: global___DataType.ValueType=..., file_name: builtins.str=..., method_parameters: collections.abc.Mapping[builtins.str, google.protobuf.any_pb2.Any] | None=..., file_extension: builtins.str=..., tags: collections.abc.Iterable[builtins.str] | None=..., dataset_ids: collections.abc.Iterable[builtins.str] | None=...) -> None:
+         ...
+ 
+-    def ClearField(self, field_name: typing.Literal['component_name', b'component_name', 'component_type', b'component_type', 'file_extension', b'file_extension', 'file_name', b'file_name', 'method_name', b'method_name', 'method_parameters', b'method_parameters', 'part_id', b'part_id', 'tags', b'tags', 'type', b'type']) -> None:
++    def ClearField(self, field_name: typing.Literal['component_name', b'component_name', 'component_type', b'component_type', 'dataset_ids', b'dataset_ids', 'file_extension', b'file_extension', 'file_name', b'file_name', 'method_name', b'method_name', 'method_parameters', b'method_parameters', 'part_id', b'part_id', 'tags', b'tags', 'type', b'type']) -> None:
+         ...
+ global___UploadMetadata = UploadMetadata
+ 
+diff --git a/src/viam/version_metadata.py b/src/viam/version_metadata.py
+index b14e9b5e2..1709bb23d 100644
+--- a/src/viam/version_metadata.py
++++ b/src/viam/version_metadata.py
+@@ -1,4 +1,4 @@
+ __version__ = "0.50.0"
+ 
+-API_VERSION = "v0.1.455"
++API_VERSION = "v0.1.456"
+ SDK_VERSION = __version__

--- a/ai_updater/tests/scenario-6/expected/src/components/gripper/client.ts
+++ b/ai_updater/tests/scenario-6/expected/src/components/gripper/client.ts
@@ -1,0 +1,99 @@
+import { Struct, type JsonValue } from '@bufbuild/protobuf';
+import type { CallOptions, PromiseClient } from '@connectrpc/connect';
+import { GripperService } from '../../gen/component/gripper/v1/gripper_connect';
+import {
+  GrabRequest,
+  IsMovingRequest,
+  OpenRequest,
+  StopRequest,
+} from '../../gen/component/gripper/v1/gripper_pb';
+import type { RobotClient } from '../../robot';
+import type { Options } from '../../types';
+import { doCommandFromClient } from '../../utils';
+import type { Gripper } from './gripper';
+import { GetGeometriesRequest } from '../../gen/common/v1/common_pb';
+
+/**
+ * A gRPC-web client for the Gripper component.
+ *
+ * @group Clients
+ */
+export class GripperClient implements Gripper {
+  private client: PromiseClient<typeof GripperService>;
+  public readonly name: string;
+  private readonly options: Options;
+  public callOptions: CallOptions = { headers: {} as Record<string, string> };
+
+  constructor(client: RobotClient, name: string, options: Options = {}) {
+    this.client = client.createServiceClient(GripperService);
+    this.name = name;
+    this.options = options;
+  }
+
+  async getGeometries(extra = {}, callOptions = this.callOptions) {
+    const request = new GetGeometriesRequest({
+      name: this.name,
+      extra: Struct.fromJson(extra),
+    });
+
+    const response = await this.client.getGeometries(request, callOptions);
+    return response.geometries;
+  }
+
+  async open(extra = {}, callOptions = this.callOptions) {
+    const request = new OpenRequest({
+      name: this.name,
+      extra: Struct.fromJson(extra),
+    });
+
+    this.options.requestLogger?.(request);
+
+    await this.client.open(request, callOptions);
+  }
+
+  async grab(extra = {}, callOptions = this.callOptions) {
+    const request = new GrabRequest({
+      name: this.name,
+      extra: Struct.fromJson(extra),
+    });
+
+    this.options.requestLogger?.(request);
+
+    await this.client.grab(request, callOptions);
+  }
+
+  async stop(extra = {}, callOptions = this.callOptions) {
+    const request = new StopRequest({
+      name: this.name,
+      extra: Struct.fromJson(extra),
+    });
+
+    this.options.requestLogger?.(request);
+
+    await this.client.stop(request, callOptions);
+  }
+
+  async isMoving(callOptions = this.callOptions) {
+    const request = new IsMovingRequest({
+      name: this.name,
+    });
+
+    this.options.requestLogger?.(request);
+
+    const resp = await this.client.isMoving(request, callOptions);
+    return resp.isMoving;
+  }
+
+  async doCommand(
+    command: Struct,
+    callOptions = this.callOptions
+  ): Promise<JsonValue> {
+    return doCommandFromClient(
+      this.client.doCommand,
+      this.name,
+      command,
+      this.options,
+      callOptions
+    );
+  }
+}

--- a/ai_updater/tests/scenario-6/expected/src/components/gripper/gripper.ts
+++ b/ai_updater/tests/scenario-6/expected/src/components/gripper/gripper.ts
@@ -1,0 +1,93 @@
+import type { Struct } from '@bufbuild/protobuf';
+import type { Resource } from '../../types';
+import type { Geometry } from '../../gen/common/v1/common_pb';
+
+/** Represents a physical robotic gripper. */
+export interface Gripper extends Resource {
+  /**
+   * Get the geometries of the component in their current configuration.
+   *
+   * @example
+   *
+   * ```ts
+   * const gripper = new VIAM.GripperClient(machine, 'my_gripper');
+   *
+   * // Get the geometries of this component
+   * const geometries = await gripper.getGeometries();
+   * console.log('Geometries:', geometries);
+   * ```
+   *
+   * For more information, see [Gripper
+   * API](https://docs.viam.com/dev/reference/apis/components/gripper/#getgeometries).
+   */
+  getGeometries: (extra?: Struct) => Promise<Geometry[]>;
+
+  /**
+   * Open a gripper of the underlying robot.
+   *
+   * @example
+   *
+   * ```ts
+   * const gripper = new VIAM.GripperClient(machine, 'my_gripper');
+   *
+   * // Open the gripper
+   * await gripper.open();
+   * ```
+   *
+   * For more information, see [Gripper
+   * API](https://docs.viam.com/dev/reference/apis/components/gripper/#open).
+   */
+  open: (extra?: Struct) => Promise<void>;
+
+  /**
+   * Request a gripper of the underlying robot to grab.
+   *
+   * @example
+   *
+   * ```ts
+   * const gripper = new VIAM.GripperClient(machine, 'my_gripper');
+   *
+   * // Close the gripper to grab
+   * await gripper.grab();
+   * ```
+   *
+   * For more information, see [Gripper
+   * API](https://docs.viam.com/dev/reference/apis/components/gripper/#grab).
+   */
+  grab: (extra?: Struct) => Promise<void>;
+
+  /**
+   * Stop a robot's gripper.
+   *
+   * @example
+   *
+   * ```ts
+   * const gripper = new VIAM.GripperClient(machine, 'my_gripper');
+   *
+   * // Stop the gripper's current motion
+   * await gripper.stop();
+   * ```
+   *
+   * For more information, see [Gripper
+   * API](https://docs.viam.com/dev/reference/apis/components/gripper/#stop).
+   */
+  stop: (extra?: Struct) => Promise<void>;
+
+  /**
+   * Report if the gripper is in motion.
+   *
+   * @example
+   *
+   * ```ts
+   * const gripper = new VIAM.GripperClient(machine, 'my_gripper');
+   *
+   * // Check if the gripper is currently moving
+   * const moving = await gripper.isMoving();
+   * console.log('Gripper is moving:', moving);
+   * ```
+   *
+   * For more information, see [Gripper
+   * API](https://docs.viam.com/dev/reference/apis/components/gripper/#ismoving).
+   */
+  isMoving: () => Promise<boolean>;
+}

--- a/ai_updater/tests/scenario-6/expected/src/types.ts
+++ b/ai_updater/tests/scenario-6/expected/src/types.ts
@@ -1,0 +1,85 @@
+import { Struct, type JsonValue, type PlainMessage } from '@bufbuild/protobuf';
+
+export { Code, ConnectError } from '@connectrpc/connect';
+export { ConnectionClosedError } from './rpc';
+
+export interface Options {
+  requestLogger?: (req: unknown) => void;
+}
+
+export interface Resource {
+  /** The name of the resource. */
+  readonly name: string;
+
+  /**
+   * Send/Receive arbitrary commands to the resource.
+   *
+   * @example
+   *
+   * ```ts
+   * import { Struct } from '@viamrobotics/sdk';
+   *
+   * const result = await resource.doCommand(
+   *   Struct.fromJson({
+   *     myCommand: { key: 'value' },
+   *   })
+   * );
+   * ```
+   *
+   * @param command - The command to execute.
+   */
+  doCommand(command: Struct): Promise<JsonValue>;
+}
+
+import * as commonApi from './gen/common/v1/common_pb';
+
+export type Capsule = PlainMessage<commonApi.Capsule>;
+export type GeoGeometry = PlainMessage<commonApi.GeoGeometry>;
+export type GeoPoint = PlainMessage<commonApi.GeoPoint>;
+export type GeometriesInFrame = PlainMessage<commonApi.GeometriesInFrame>;
+export type Geometry = PlainMessage<commonApi.Geometry>;
+export type Orientation = PlainMessage<commonApi.Orientation>;
+export type Pose = PlainMessage<commonApi.Pose>;
+export type PoseInFrame = PlainMessage<commonApi.PoseInFrame>;
+export type RectangularPrism = PlainMessage<commonApi.RectangularPrism>;
+export type ResourceName = PlainMessage<commonApi.ResourceName>;
+export type Sphere = PlainMessage<commonApi.Sphere>;
+export type Transform = PlainMessage<commonApi.Transform>;
+export type Vector3 = PlainMessage<commonApi.Vector3>;
+export type WorldState = PlainMessage<commonApi.WorldState>;
+
+export const {
+  Capsule,
+  GeoGeometry,
+  GeoPoint,
+  GeometriesInFrame,
+  Geometry,
+  Orientation,
+  Pose,
+  PoseInFrame,
+  RectangularPrism,
+  ResourceName,
+  Sphere,
+  Transform,
+  Vector3,
+  WorldState,
+} = commonApi;
+
+export const isValidGeoPoint = (value: GeoPoint) => {
+  const { latitude, longitude } = value;
+
+  return !(
+    typeof latitude !== 'number' ||
+    typeof longitude !== 'number' ||
+    Number.isNaN(latitude) ||
+    Number.isNaN(longitude)
+  );
+};
+
+export {
+  Duration,
+  Struct,
+  Timestamp,
+  type JsonValue,
+  type PlainMessage,
+} from '@bufbuild/protobuf';

--- a/ai_updater/tests/scenario-7/expected/src/viam/sdk/components/gripper.hpp
+++ b/ai_updater/tests/scenario-7/expected/src/viam/sdk/components/gripper.hpp
@@ -1,0 +1,91 @@
+/// @file components/gripper.hpp
+///
+/// @brief Defines a `Gripper` component
+#pragma once
+
+#include <string>
+
+#include <viam/sdk/common/proto_value.hpp>
+#include <viam/sdk/resource/stoppable.hpp>
+
+namespace viam {
+namespace sdk {
+
+/// @defgroup Gripper Classes related to the Gripper component.
+
+/// @class Gripper gripper.hpp "components/gripper.hpp"
+/// @brief A `Gripper` represents a physical robotic gripper.
+/// @ingroup Gripper
+///
+/// This acts as an abstract parent class to be inherited from by any drivers representing
+/// specific gripper implementations. This class cannot be used on its own.
+class Gripper : public Component, public Stoppable {
+   public:
+    /// @struct holding_status
+    /// @brief whether the gripper is holding something (along with other contextual info)
+    struct holding_status {
+        bool is_holding_something;
+        ProtoStruct meta;
+    };
+
+    /// @brief Open the gripper.
+    inline void open() {
+        return open({});
+    }
+
+    /// @brief Open the gripper.
+    /// @param extra Any additional arguments to the method.
+    virtual void open(const ProtoStruct& extra) = 0;
+
+    /// @brief Instruct the gripper to grab.
+    /// @return bool indicating if the gripper grabbed something.
+    inline bool grab() {
+        return grab({});
+    }
+
+    /// @brief Instruct the gripper to grab.
+    /// @param extra Any additional arguments to the method.
+    /// @return bool indicating if the gripper grabbed something.
+    virtual bool grab(const ProtoStruct& extra) = 0;
+
+    /// @brief Reports whether the gripper is holding onto a object (alongside other information).
+    /// @return holding_status (see `holding_status` struct for more info).
+    inline holding_status is_holding_something() {
+        return holding_status({});
+    }
+
+    /// @brief Reports whether the gripper is holding onto a object (alongside other information).
+    /// @param extra Any additional arguments to the method.
+    /// @return holding_status (see `holding_status` struct for more info).
+    virtual holding_status is_holding_something(const ProtoStruct& extra) = 0;
+
+    /// @brief Reports if the gripper is in motion.
+    virtual bool is_moving() = 0;
+
+    /// @brief Send/receive arbitrary commands to the resource.
+    /// @param Command the command to execute.
+    /// @return The result of the executed command.
+    virtual ProtoStruct do_command(const ProtoStruct& command) = 0;
+
+    /// @brief Returns `GeometryConfig`s associated with the calling arm
+    inline std::vector<GeometryConfig> get_geometries() {
+        return get_geometries({});
+    }
+
+    /// @brief Returns `GeometryConfig`s associated with the calling arm
+    /// @param extra Any additional arguments to the method
+    virtual std::vector<GeometryConfig> get_geometries(const ProtoStruct& extra) = 0;
+
+    API api() const override;
+
+   protected:
+    explicit Gripper(std::string name);
+};
+
+template <>
+struct API::traits<Gripper> {
+    static API api();
+};
+
+}  // namespace sdk
+}  // namespace viam

--- a/ai_updater/tests/scenario-7/expected/src/viam/sdk/components/private/generic_client.cpp
+++ b/ai_updater/tests/scenario-7/expected/src/viam/sdk/components/private/generic_client.cpp
@@ -1,0 +1,38 @@
+#include <viam/sdk/components/private/generic_client.hpp>
+
+#include <utility>
+
+#include <viam/api/common/v1/common.pb.h>
+#include <viam/api/component/generic/v1/generic.grpc.pb.h>
+
+#include <viam/sdk/common/client_helper.hpp>
+#include <viam/sdk/common/proto_value.hpp>
+#include <viam/sdk/common/utils.hpp>
+#include <viam/sdk/config/resource.hpp>
+#include <viam/sdk/robot/client.hpp>
+
+namespace viam {
+namespace sdk {
+namespace impl {
+
+GenericComponentClient::GenericComponentClient(std::string name,
+                                               std::shared_ptr<grpc::Channel> channel)
+    : GenericComponent(std::move(name)),
+      stub_(viam::component::generic::v1::GenericService::NewStub(channel)),
+      channel_(std::move(channel)) {}
+
+ProtoStruct GenericComponentClient::do_command(const ProtoStruct& command) {
+    return make_client_helper(this, *stub_, &StubType::DoCommand)
+        .with([&](auto& request) { *request.mutable_command() = to_proto(command); })
+        .invoke([](auto& response) { return from_proto(response.result()); });
+}
+
+std::vector<GeometryConfig> GenericComponentClient::get_geometries(const ProtoStruct& extra) {
+    return make_client_helper(this, *stub_, &StubType::GetGeometries)
+        .with(extra)
+        .invoke([](auto& response) { return from_proto(response); });
+}
+
+}  // namespace impl
+}  // namespace sdk
+}  // namespace viam

--- a/ai_updater/tests/scenario-7/expected/src/viam/sdk/components/private/generic_client.hpp
+++ b/ai_updater/tests/scenario-7/expected/src/viam/sdk/components/private/generic_client.hpp
@@ -1,0 +1,44 @@
+/// @file components/private/generic_client.hpp
+///
+/// @brief Implements a gRPC client for the `GenericComponent`.
+#pragma once
+
+#include <grpcpp/channel.h>
+
+#include <viam/api/component/generic/v1/generic.grpc.pb.h>
+
+#include <viam/sdk/components/generic.hpp>
+#include <viam/sdk/robot/client.hpp>
+
+namespace viam {
+namespace sdk {
+namespace impl {
+
+/// @class GenericComponentClient
+/// @brief gRPC client implementation of a `GenericComponent`.
+/// @ingroup GenericComponent
+class GenericComponentClient : public GenericComponent {
+   public:
+    using interface_type = GenericComponent;
+    GenericComponentClient(std::string name, std::shared_ptr<grpc::Channel> channel);
+    ProtoStruct do_command(const ProtoStruct& command) override;
+    std::vector<GeometryConfig> get_geometries(const ProtoStruct& extra) override;
+
+   protected:
+    // This constructor leaves the `channel_` as a nullptr. This is useful for testing
+    // purposes, but renders it unusable for production use. Care should be taken to
+    // avoid use of this constructor outside of tests.
+    GenericComponentClient(
+        std::string name,
+        std::unique_ptr<viam::component::generic::v1::GenericService::StubInterface> stub)
+        : GenericComponent(std::move(name)), stub_(std::move(stub)) {}
+
+   private:
+    using StubType = viam::component::generic::v1::GenericService::StubInterface;
+    std::unique_ptr<StubType> stub_;
+    std::shared_ptr<grpc::Channel> channel_;
+};
+
+}  // namespace impl
+}  // namespace sdk
+}  // namespace viam

--- a/ai_updater/tests/scenario-7/expected/src/viam/sdk/components/private/generic_server.cpp
+++ b/ai_updater/tests/scenario-7/expected/src/viam/sdk/components/private/generic_server.cpp
@@ -1,0 +1,39 @@
+#include <viam/sdk/components/private/generic_server.hpp>
+
+#include <viam/sdk/common/private/service_helper.hpp>
+#include <viam/sdk/components/generic.hpp>
+#include <viam/sdk/rpc/server.hpp>
+
+namespace viam {
+namespace sdk {
+namespace impl {
+
+GenericComponentServer::GenericComponentServer(std::shared_ptr<ResourceManager> manager)
+    : ResourceServer(std::move(manager)) {}
+
+::grpc::Status GenericComponentServer::DoCommand(
+    ::grpc::ServerContext*,
+    const ::viam::common::v1::DoCommandRequest* request,
+    ::viam::common::v1::DoCommandResponse* response) noexcept {
+    return make_service_helper<GenericComponent>(
+        "GenericComponentServer::DoCommand", this, request)([&](auto&, auto& generic) {
+        const ProtoStruct result = generic->do_command(from_proto(request->command()));
+        *response->mutable_result() = to_proto(result);
+    });
+}
+::grpc::Status GenericComponentServer::GetGeometries(
+    ::grpc::ServerContext*,
+    const ::viam::common::v1::GetGeometriesRequest* request,
+    ::viam::common::v1::GetGeometriesResponse* response) noexcept {
+    return make_service_helper<GenericComponent>(
+        "GenericComponentServer::GetGeometries", this, request)([&](auto& helper, auto& generic) {
+        const std::vector<GeometryConfig> geometries = generic->get_geometries(helper.getExtra());
+        for (const auto& geometry : geometries) {
+            *response->mutable_geometries()->Add() = to_proto(geometry);
+        }
+    });
+}
+
+}  // namespace impl
+}  // namespace sdk
+}  // namespace viam

--- a/ai_updater/tests/scenario-7/expected/src/viam/sdk/components/private/generic_server.hpp
+++ b/ai_updater/tests/scenario-7/expected/src/viam/sdk/components/private/generic_server.hpp
@@ -1,0 +1,38 @@
+/// @file components/private/generic_server.hpp
+///
+/// @brief Implements a gRPC server for the `GenericComponent`.
+#pragma once
+
+#include <viam/api/common/v1/common.grpc.pb.h>
+#include <viam/api/component/generic/v1/generic.grpc.pb.h>
+
+#include <viam/sdk/components/generic.hpp>
+#include <viam/sdk/resource/resource_manager.hpp>
+#include <viam/sdk/resource/resource_server_base.hpp>
+
+namespace viam {
+namespace sdk {
+namespace impl {
+
+/// @class GenericComponentServer
+/// @brief gRPC server implementation of a `GenericComponent`.
+/// @ingroup GenericComponent
+class GenericComponentServer : public ResourceServer,
+                               public viam::component::generic::v1::GenericService::Service {
+   public:
+    using interface_type = GenericComponent;
+    using service_type = component::generic::v1::GenericService;
+    explicit GenericComponentServer(std::shared_ptr<ResourceManager> manager);
+
+    ::grpc::Status DoCommand(::grpc::ServerContext* context,
+                             const ::viam::common::v1::DoCommandRequest* request,
+                             ::viam::common::v1::DoCommandResponse* response) noexcept override;
+    ::grpc::Status GetGeometries(
+        ::grpc::ServerContext* context,
+        const ::viam::common::v1::GetGeometriesRequest* request,
+        ::viam::common::v1::GetGeometriesResponse* response) noexcept override;
+};
+
+}  // namespace impl
+}  // namespace sdk
+}  // namespace viam

--- a/ai_updater/tests/scenario-7/expected/src/viam/sdk/tests/mocks/mock_gripper.cpp
+++ b/ai_updater/tests/scenario-7/expected/src/viam/sdk/tests/mocks/mock_gripper.cpp
@@ -1,0 +1,48 @@
+#include <viam/sdk/tests/mocks/mock_gripper.hpp>
+
+#include <viam/sdk/tests/test_utils.hpp>
+
+namespace viam {
+namespace sdktests {
+namespace gripper {
+
+using namespace viam::sdk;
+
+std::shared_ptr<MockGripper> MockGripper::get_mock_gripper() {
+    return std::make_shared<MockGripper>("mock_gripper");
+}
+
+void MockGripper::open(const ProtoStruct&) {
+    peek_open_called = true;
+}
+
+bool MockGripper::grab(const ProtoStruct&) {
+    return true;
+}
+
+void MockGripper::stop(const ProtoStruct&) {
+    peek_stop_called = true;
+}
+
+bool MockGripper::is_moving() {
+    return false;
+}
+
+Gripper::holding_status MockGripper::is_holding_something(const ProtoStruct& extra) {
+    Gripper::holding_status res;
+    res.is_holding_something = false;
+    res.meta = extra;
+    return res;
+}
+
+ProtoStruct MockGripper::do_command(const ProtoStruct& command) {
+    return (peek_command = command);
+}
+
+std::vector<GeometryConfig> MockGripper::get_geometries(const ProtoStruct&) {
+    return fake_geometries();
+}
+
+}  // namespace gripper
+}  // namespace sdktests
+}  // namespace viam

--- a/ai_updater/tests/scenario-7/expected/src/viam/sdk/tests/mocks/mock_gripper.hpp
+++ b/ai_updater/tests/scenario-7/expected/src/viam/sdk/tests/mocks/mock_gripper.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include <viam/sdk/components/gripper.hpp>
+
+namespace viam {
+namespace sdktests {
+namespace gripper {
+
+class MockGripper : public sdk::Gripper {
+   public:
+    MockGripper(std::string name) : Gripper(std::move(name)) {}
+
+    static std::shared_ptr<MockGripper> get_mock_gripper();
+
+    void open(const sdk::ProtoStruct& extra) override;
+    bool grab(const sdk::ProtoStruct& extra) override;
+    Gripper::holding_status is_holding_something(const sdk::ProtoStruct& extra) override;
+    void stop(const sdk::ProtoStruct& extra) override;
+    bool is_moving() override;
+    sdk::ProtoStruct do_command(const sdk::ProtoStruct& command) override;
+    std::vector<sdk::GeometryConfig> get_geometries(const sdk::ProtoStruct& extra) override;
+
+    bool peek_open_called{false};
+    bool peek_stop_called{false};
+    sdk::ProtoStruct peek_command;
+};
+
+}  // namespace gripper
+}  // namespace sdktests
+}  // namespace viam

--- a/ai_updater/tests/scenario-7/expected/src/viam/sdk/tests/test_gripper.cpp
+++ b/ai_updater/tests/scenario-7/expected/src/viam/sdk/tests/test_gripper.cpp
@@ -1,0 +1,92 @@
+#define BOOST_TEST_MODULE test module test_gripper
+
+#include <boost/test/included/unit_test.hpp>
+
+#include <viam/sdk/components/gripper.hpp>
+#include <viam/sdk/tests/mocks/mock_gripper.hpp>
+#include <viam/sdk/tests/test_utils.hpp>
+
+BOOST_TEST_DONT_PRINT_LOG_VALUE(std::vector<viam::sdk::GeometryConfig>)
+
+BOOST_TEST_DONT_PRINT_LOG_VALUE(viam::sdk::ProtoValue)
+
+namespace viam {
+namespace sdktests {
+
+using namespace gripper;
+using namespace viam::sdk;
+
+BOOST_AUTO_TEST_SUITE(test_gripper)
+
+BOOST_AUTO_TEST_CASE(mock_get_api) {
+    const MockGripper gripper("mock_gripper");
+    auto api = gripper.api();
+    auto static_api = API::get<Gripper>();
+
+    BOOST_CHECK_EQUAL(api, static_api);
+    BOOST_CHECK_EQUAL(static_api.resource_subtype(), "gripper");
+}
+
+BOOST_AUTO_TEST_CASE(test_open) {
+    std::shared_ptr<MockGripper> mock = MockGripper::get_mock_gripper();
+    client_to_mock_pipeline<Gripper>(mock, [&](Gripper& client) {
+        client.open();
+        BOOST_CHECK(mock->peek_open_called);
+    });
+}
+
+BOOST_AUTO_TEST_CASE(test_grab) {
+    std::shared_ptr<MockGripper> mock = MockGripper::get_mock_gripper();
+    client_to_mock_pipeline<Gripper>(mock, [](Gripper& client) { BOOST_CHECK(client.grab()); });
+}
+
+BOOST_AUTO_TEST_CASE(test_is_holding_something) {
+    std::shared_ptr<MockGripper> mock = MockGripper::get_mock_gripper();
+    client_to_mock_pipeline<Gripper>(mock, [](Gripper& client) {
+        const ProtoStruct extra = {
+            {"BEEP", "BOOP"},
+        };
+        Gripper::holding_status holding_status = client.is_holding_something(extra);
+        BOOST_CHECK_EQUAL(holding_status.is_holding_something, false);
+        BOOST_CHECK_EQUAL(holding_status.meta["BEEP"], ProtoValue("BOOP"));
+    });
+}
+
+BOOST_AUTO_TEST_CASE(test_stop) {
+    std::shared_ptr<MockGripper> mock = MockGripper::get_mock_gripper();
+    client_to_mock_pipeline<Gripper>(mock, [&](Gripper& client) {
+        mock->peek_stop_called = false;
+        client.stop();
+        BOOST_CHECK(mock->peek_stop_called);
+    });
+}
+
+BOOST_AUTO_TEST_CASE(test_is_moving) {
+    std::shared_ptr<MockGripper> mock = MockGripper::get_mock_gripper();
+    client_to_mock_pipeline<Gripper>(mock,
+                                     [](Gripper& client) { BOOST_CHECK(!client.is_moving()); });
+}
+
+BOOST_AUTO_TEST_CASE(test_do_command) {
+    std::shared_ptr<MockGripper> mock = MockGripper::get_mock_gripper();
+    client_to_mock_pipeline<Gripper>(mock, [](Gripper& client) {
+        ProtoStruct expected = fake_map();
+
+        ProtoStruct command = fake_map();
+        ProtoStruct result_map = client.do_command(command);
+
+        BOOST_CHECK(result_map.at("test") == expected.at("test"));
+    });
+}
+
+BOOST_AUTO_TEST_CASE(test_get_geometries) {
+    std::shared_ptr<MockGripper> mock = MockGripper::get_mock_gripper();
+    client_to_mock_pipeline<Gripper>(mock, [](Gripper& client) {
+        const auto& geometries = client.get_geometries();
+        BOOST_CHECK_EQUAL(geometries, fake_geometries());
+    });
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+}  // namespace sdktests
+}  // namespace viam

--- a/ai_updater/tests/scenario-8/expected/lib/src/components/gripper/client.dart
+++ b/ai_updater/tests/scenario-8/expected/lib/src/components/gripper/client.dart
@@ -1,0 +1,72 @@
+import 'package:grpc/grpc_connection_interface.dart';
+
+import '../../gen/common/v1/common.pb.dart';
+import '../../gen/component/gripper/v1/gripper.pbgrpc.dart';
+import '../../gen/google/protobuf/struct.pb.dart';
+import '../../resource/base.dart';
+import '../../utils.dart';
+import 'gripper.dart';
+
+/// {@category Components}
+/// gRPC client for the [Gripper] component.
+class GripperClient extends Gripper with RPCDebugLoggerMixin implements ResourceRPCClient {
+  @override
+  final String name;
+
+  @override
+  ClientChannelBase channel;
+
+  @override
+  GripperServiceClient get client => GripperServiceClient(channel);
+
+  GripperClient(this.name, this.channel);
+
+  @override
+  Future<void> grab({Map<String, dynamic>? extra}) async {
+    final request = GrabRequest()
+      ..name = name
+      ..extra = extra?.toStruct() ?? Struct();
+    await client.grab(request, options: callOptions);
+  }
+
+  @override
+  Future<bool> isMoving() async {
+    final request = IsMovingRequest()..name = name;
+    final response = await client.isMoving(request, options: callOptions);
+    return response.isMoving;
+  }
+
+  @override
+  Future<void> open({Map<String, dynamic>? extra}) async {
+    final request = OpenRequest()
+      ..name = name
+      ..extra = extra?.toStruct() ?? Struct();
+    await client.open(request, options: callOptions);
+  }
+
+  @override
+  Future<void> stop({Map<String, dynamic>? extra}) async {
+    final request = StopRequest()
+      ..name = name
+      ..extra = extra?.toStruct() ?? Struct();
+    await client.stop(request, options: callOptions);
+  }
+
+  @override
+  Future<Map<String, dynamic>> doCommand(Map<String, dynamic> command) async {
+    final request = DoCommandRequest()
+      ..name = name
+      ..command = command.toStruct();
+    final response = await client.doCommand(request, options: callOptions);
+    return response.result.toMap();
+  }
+
+  @override
+  Future<Kinematics> getKinematics({Map<String, dynamic>? extra}) async {
+    final request = GetKinematicsRequest()
+      ..name = name
+      ..extra = extra?.toStruct() ?? Struct();
+    final response = await client.getKinematics(request, options: callOptions);
+    return Kinematics.fromProto(response);
+  }
+}

--- a/ai_updater/tests/scenario-8/expected/lib/src/components/gripper/gripper.dart
+++ b/ai_updater/tests/scenario-8/expected/lib/src/components/gripper/gripper.dart
@@ -1,0 +1,90 @@
+import '../../gen/common/v1/common.pb.dart';
+import '../../resource/base.dart';
+import '../../robot/client.dart';
+
+/// {@category Viam SDK}
+class Kinematics {
+  KinematicsFileFormat format;
+  List<int> raw;
+
+  Kinematics(this.format, this.raw);
+
+  factory Kinematics.fromProto(GetKinematicsResponse gkResponse) {
+    return Kinematics(gkResponse.format, gkResponse.kinematicsData);
+  }
+}
+
+/// {@category Components}
+/// Gripper represents a physical Gripper which can open and close.
+///
+/// For more information, see [Gripper component](https://docs.viam.com/dev/reference/apis/components/gripper/).
+abstract class Gripper extends Resource {
+  static const Subtype subtype = Subtype(resourceNamespaceRDK, resourceTypeComponent, 'gripper');
+
+  /// Open the [Gripper].
+  ///
+  /// ```
+  /// await myGripper.open();
+  /// ```
+  ///
+  /// For more information, see [Gripper component](https://docs.viam.com/dev/reference/apis/components/gripper/#open).
+  Future<void> open({Map<String, dynamic>? extra});
+
+  /// Close the [Gripper]
+  ///
+  /// ```
+  /// await myGripper.grab();
+  /// ```
+  ///
+  /// For more information, see [Gripper component](https://docs.viam.com/dev/reference/apis/components/gripper/#grab).
+  Future<void> grab({Map<String, dynamic>? extra});
+
+  /// Stop all motion of the [Gripper]. It is assumed the [Gripper] stops immediately.
+  ///
+  /// ```
+  /// await myGripper.stop();
+  /// ```
+  ///
+  /// For more information, see [Gripper component](https://docs.viam.com/dev/reference/apis/components/gripper/#stop).
+  Future<void> stop({Map<String, dynamic>? extra});
+
+  /// Whether the [Gripper] is currently moving.
+  ///
+  /// ```
+  /// var isItMoving = await myGripper.isMoving();
+  /// ```
+  ///
+  /// For more information, see [Gripper component](https://docs.viam.com/dev/reference/apis/components/gripper/#ismoving).
+  Future<bool> isMoving();
+
+  /// Get the kinematics data associated with the [Gripper]
+  ///
+  /// ```
+  /// var kinematics = await myGripper.getKinematics();
+  /// ```
+  ///
+  /// For more information, see [Gripper component](https://docs.viam.com/dev/reference/apis/components/gripper/#getkinematics).
+  Future<Kinematics> getKinematics({Map<String, dynamic>? extra});
+
+  /// Get the [ResourceName] for the [Gripper] with the given [name]
+  ///
+  /// ```
+  /// final myGripperResourceName = myGripper.getResourceName("my_gripper");
+  /// ```
+  ///
+  /// For more information, see [Gripper component](https://docs.viam.com/dev/reference/apis/components/gripper/#getresourcename).
+  static ResourceName getResourceName(String name) {
+    return Gripper.subtype.getResourceName(name);
+  }
+
+  /// Get the [Gripper] named [name] from the provided robot.
+  ///
+  /// ```
+  /// final myGripper = Gripper.fromRobot(myRobotClient, "my_gripper");
+  /// ```
+  ///
+  /// For more information, see [Gripper component](https://docs.viam.com/dev/reference/apis/components/gripper/).
+  static Gripper fromRobot(RobotClient robot, String name) {
+    return robot.getResource(Gripper.getResourceName(name));
+  }
+}

--- a/ai_updater/tests/scenario-8/expected/lib/src/components/gripper/service.dart
+++ b/ai_updater/tests/scenario-8/expected/lib/src/components/gripper/service.dart
@@ -1,0 +1,73 @@
+import 'package:grpc/grpc.dart';
+
+import '../../gen/common/v1/common.pb.dart';
+import '../../gen/component/gripper/v1/gripper.pbgrpc.dart';
+import '../../resource/manager.dart';
+import '../../utils.dart';
+import 'gripper.dart';
+
+/// {@category Components}
+/// gRPC Service for a [Gripper]
+class GripperService extends GripperServiceBase {
+  final ResourceManager _manager;
+
+  GripperService(this._manager);
+
+  Gripper _fromManager(String name) {
+    try {
+      return _manager.getResource(Gripper.getResourceName(name));
+    } catch (e) {
+      throw GrpcError.notFound(e.toString());
+    }
+  }
+
+  @override
+  Future<DoCommandResponse> doCommand(ServiceCall call, DoCommandRequest request) async {
+    final gantry = _fromManager(request.name);
+    final response = await gantry.doCommand(request.command.toMap());
+    return DoCommandResponse()..result = response.toStruct();
+  }
+
+  @override
+  Future<GetGeometriesResponse> getGeometries(ServiceCall call, GetGeometriesRequest request) {
+    // TODO: implement getGeometries
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<GrabResponse> grab(ServiceCall call, GrabRequest request) async {
+    final gripper = _fromManager(request.name);
+    await gripper.grab(extra: request.extra.toMap());
+    return GrabResponse();
+  }
+
+  @override
+  Future<IsMovingResponse> isMoving(ServiceCall call, IsMovingRequest request) async {
+    final gripper = _fromManager(request.name);
+    final response = await gripper.isMoving();
+    return IsMovingResponse()..isMoving = response;
+  }
+
+  @override
+  Future<OpenResponse> open(ServiceCall call, OpenRequest request) async {
+    final gripper = _fromManager(request.name);
+    await gripper.open(extra: request.extra.toMap());
+    return OpenResponse();
+  }
+
+  @override
+  Future<StopResponse> stop(ServiceCall call, StopRequest request) async {
+    final gripper = _fromManager(request.name);
+    await gripper.stop(extra: request.extra.toMap());
+    return StopResponse();
+  }
+
+  @override
+  Future<GetKinematicsResponse> getKinematics(ServiceCall call, GetKinematicsRequest request) async {
+    final gripper = _fromManager(request.name);
+    final response = await gripper.getKinematics(extra: request.extra.toMap());
+    return GetKinematicsResponse()
+      ..format = response.format
+      ..kinematicsData = response.raw;
+  }
+}

--- a/ai_updater/tests/scenario-8/expected/test/unit_test/components/gripper_test.dart
+++ b/ai_updater/tests/scenario-8/expected/test/unit_test/components/gripper_test.dart
@@ -1,0 +1,272 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:grpc/grpc.dart';
+import 'package:viam_sdk/src/components/gripper/service.dart';
+import 'package:viam_sdk/src/gen/common/v1/common.pb.dart';
+import 'package:viam_sdk/src/gen/component/gripper/v1/gripper.pbgrpc.dart';
+import 'package:viam_sdk/src/resource/manager.dart';
+import 'package:viam_sdk/src/utils.dart';
+import 'package:viam_sdk/viam_sdk.dart';
+
+import '../../test_utils.dart';
+
+class FakeGripper extends Gripper {
+  bool isOpen = false;
+  bool isStopped = true;
+  Map<String, dynamic>? extra;
+
+  @override
+  String name;
+
+  FakeGripper(this.name);
+
+  @override
+  Future<void> stop({Map<String, dynamic>? extra}) async {
+    isStopped = true;
+    this.extra = extra;
+  }
+
+  @override
+  Future<bool> isMoving() async {
+    return !isStopped;
+  }
+
+  @override
+  Future<Map<String, dynamic>> doCommand(Map<String, dynamic> command) async {
+    return {'command': command};
+  }
+
+  @override
+  Future<void> grab({Map<String, dynamic>? extra}) async {
+    isOpen = false;
+    isStopped = false;
+    this.extra = extra;
+  }
+
+  @override
+  Future<void> open({Map<String, dynamic>? extra}) async {
+    isOpen = true;
+    isStopped = false;
+    this.extra = extra;
+  }
+
+  @override
+  Future<Kinematics> getKinematics({Map<String, dynamic>? extra}) async {
+    this.extra = extra;
+    return Kinematics(KinematicsFileFormat.KINEMATICS_FILE_FORMAT_SVA, [1, 2, 3]);
+  }
+}
+
+void main() {
+  group('Gripper Tests', () {
+    const String name = 'gripper';
+    late FakeGripper gripper;
+
+    setUp(() {
+      gripper = FakeGripper(name);
+    });
+
+    test('open', () async {
+      expect(gripper.isOpen, false);
+      await gripper.open();
+      expect(gripper.isOpen, true);
+    });
+
+    test('grab', () async {
+      await gripper.open();
+      expect(gripper.isOpen, true);
+      await gripper.grab();
+      expect(gripper.isOpen, false);
+    });
+
+    test('stop', () async {
+      expect(gripper.isStopped, true);
+
+      await gripper.open();
+      expect(gripper.isStopped, false);
+
+      await gripper.stop();
+      expect(gripper.isStopped, true);
+    });
+
+    test('isMoving', () async {
+      expect(await gripper.isMoving(), false);
+
+      await gripper.open();
+      expect(await gripper.isMoving(), true);
+
+      await gripper.stop();
+      expect(await gripper.isMoving(), false);
+    });
+
+    test('getKinematics', () async {
+      final kd = await gripper.getKinematics();
+      expect(kd.format, KinematicsFileFormat.KINEMATICS_FILE_FORMAT_SVA);
+      expect(kd.raw, [1, 2, 3]);
+    });
+
+    test('doCommand', () async {
+      final cmd = {'foo': 'bar'};
+      final resp = await gripper.doCommand(cmd);
+      expect(resp['command'], cmd);
+    });
+
+    test('extra', () async {
+      expect(gripper.extra, null);
+      await gripper.stop(extra: {'foo': 'bar'});
+      expect(gripper.extra, {'foo': 'bar'});
+    });
+  });
+
+  group('Gripper RPC Tests', () {
+    const String name = 'gripper';
+    late FakeGripper gripper;
+    late ClientChannel channel;
+    late GripperService service;
+    late Server server;
+
+    setUp(() async {
+      gripper = FakeGripper(name);
+      final ResourceManager manager = ResourceManager();
+      manager.register(Gripper.getResourceName(name), gripper);
+      service = GripperService(manager);
+      server = Server.create(services: [service]);
+      await serveServerAtUnusedPort(server);
+      channel = ClientChannel('localhost', port: server.port!, options: const ChannelOptions(credentials: ChannelCredentials.insecure()));
+    });
+
+    tearDown(() async {
+      await channel.shutdown();
+      await server.shutdown();
+    });
+
+    group('Gripper Service Tests', () {
+      test('open', () async {
+        final client = GripperServiceClient(channel);
+        expect(gripper.isOpen, false);
+        await client.open(OpenRequest()..name = name);
+        expect(gripper.isOpen, true);
+      });
+
+      test('grab', () async {
+        final client = GripperServiceClient(channel);
+        await client.open(OpenRequest()..name = name);
+        expect(gripper.isOpen, true);
+        await client.grab(GrabRequest()..name = name);
+        expect(gripper.isOpen, false);
+      });
+
+      test('stop', () async {
+        expect(gripper.isStopped, true);
+
+        final client = GripperServiceClient(channel);
+        final request = OpenRequest()..name = name;
+        await client.open(request);
+        expect(gripper.isStopped, false);
+
+        await client.stop(StopRequest()..name = name);
+        expect(gripper.isStopped, true);
+      });
+
+      test('isMoving', () async {
+        final client = GripperServiceClient(channel);
+        IsMovingResponse resp = await client.isMoving(IsMovingRequest()..name = name);
+        expect(resp.isMoving, false);
+
+        final request = OpenRequest()..name = name;
+        await client.open(request);
+        resp = await client.isMoving(IsMovingRequest()..name = name);
+        expect(resp.isMoving, true);
+
+        await client.stop(StopRequest()..name = name);
+        resp = await client.isMoving(IsMovingRequest()..name = name);
+        expect(resp.isMoving, false);
+      });
+
+      test('getKinematics', () async {
+        final client = GripperServiceClient(channel);
+        final resp = await client.getKinematics(GetKinematicsRequest()..name = name);
+        expect(resp.format, KinematicsFileFormat.KINEMATICS_FILE_FORMAT_SVA);
+        expect(resp.kinematicsData, [1, 2, 3]);
+      });
+
+      test('doCommand', () async {
+        final cmd = {'foo': 'bar'};
+
+        final client = GripperServiceClient(channel);
+        final resp = await client.doCommand(DoCommandRequest()
+          ..name = name
+          ..command = cmd.toStruct());
+        expect(resp.result.toMap()['command'], cmd);
+      });
+
+      test('extra', () async {
+        expect(gripper.extra, null);
+
+        final client = GripperServiceClient(channel);
+        await client.stop(StopRequest()
+          ..name = name
+          ..extra = {'foo': 'bar'}.toStruct());
+        expect(gripper.extra, {'foo': 'bar'});
+      });
+    });
+    group('Gripper Client Tests', () {
+      test('open', () async {
+        final client = GripperClient(name, channel);
+        expect(gripper.isOpen, false);
+        await client.open();
+        expect(gripper.isOpen, true);
+      });
+
+      test('grab', () async {
+        final client = GripperClient(name, channel);
+        await client.open();
+        expect(gripper.isOpen, true);
+        await client.grab();
+        expect(gripper.isOpen, false);
+      });
+
+      test('stop', () async {
+        expect(gripper.isStopped, true);
+
+        final client = GripperClient(name, channel);
+        await client.open();
+        expect(gripper.isStopped, false);
+
+        await client.stop();
+        expect(gripper.isStopped, true);
+      });
+
+      test('isMoving', () async {
+        expect(await gripper.isMoving(), false);
+
+        final client = GripperClient(name, channel);
+        await client.open();
+        expect(await client.isMoving(), true);
+
+        await gripper.stop();
+        expect(await client.isMoving(), false);
+      });
+
+      test('getKinematics', () async {
+        final client = GripperClient(name, channel);
+        final kd = await client.getKinematics();
+        expect(kd.format, KinematicsFileFormat.KINEMATICS_FILE_FORMAT_SVA);
+        expect(kd.raw, [1, 2, 3]);
+      });
+
+      test('doCommand', () async {
+        final cmd = {'foo': 'bar'};
+        final client = GripperClient(name, channel);
+        final resp = await client.doCommand(cmd);
+        expect(resp['command'], cmd);
+      });
+
+      test('extra', () async {
+        expect(gripper.extra, null);
+        final client = GripperClient(name, channel);
+        await client.stop(extra: {'foo': 'bar'});
+        expect(gripper.extra, {'foo': 'bar'});
+      });
+    });
+  });
+}

--- a/ai_updater/tests/scenario-8/proto_diff.txt
+++ b/ai_updater/tests/scenario-8/proto_diff.txt
@@ -1,0 +1,56 @@
+diff --git a/lib/src/gen/component/gripper/v1/gripper.pbgrpc.dart b/lib/src/gen/component/gripper/v1/gripper.pbgrpc.dart
+index c438e6efb4b..3a12e73db55 100644
+--- a/lib/src/gen/component/gripper/v1/gripper.pbgrpc.dart
++++ b/lib/src/gen/component/gripper/v1/gripper.pbgrpc.dart
+@@ -46,6 +46,10 @@ class GripperServiceClient extends $grpc.Client {
+       '/viam.component.gripper.v1.GripperService/GetGeometries',
+       ($16.GetGeometriesRequest value) => value.writeToBuffer(),
+       ($core.List<$core.int> value) => $16.GetGeometriesResponse.fromBuffer(value));
++  static final _$getKinematics = $grpc.ClientMethod<$16.GetKinematicsRequest, $16.GetKinematicsResponse>(
++      '/viam.component.gripper.v1.GripperService/GetKinematics',
++      ($16.GetKinematicsRequest value) => value.writeToBuffer(),
++      ($core.List<$core.int> value) => $16.GetKinematicsResponse.fromBuffer(value));
+ 
+   GripperServiceClient($grpc.ClientChannel channel,
+       {$grpc.CallOptions? options,
+@@ -76,6 +80,10 @@ class GripperServiceClient extends $grpc.Client {
+   $grpc.ResponseFuture<$16.GetGeometriesResponse> getGeometries($16.GetGeometriesRequest request, {$grpc.CallOptions? options}) {
+     return $createUnaryCall(_$getGeometries, request, options: options);
+   }
++
++  $grpc.ResponseFuture<$16.GetKinematicsResponse> getKinematics($16.GetKinematicsRequest request, {$grpc.CallOptions? options}) {
++    return $createUnaryCall(_$getKinematics, request, options: options);
++  }
+ }
+ 
+ @$pb.GrpcServiceName('viam.component.gripper.v1.GripperService')
+@@ -125,6 +133,13 @@ abstract class GripperServiceBase extends $grpc.Service {
+         false,
+         ($core.List<$core.int> value) => $16.GetGeometriesRequest.fromBuffer(value),
+         ($16.GetGeometriesResponse value) => value.writeToBuffer()));
++    $addMethod($grpc.ServiceMethod<$16.GetKinematicsRequest, $16.GetKinematicsResponse>(
++        'GetKinematics',
++        getKinematics_Pre,
++        false,
++        false,
++        ($core.List<$core.int> value) => $16.GetKinematicsRequest.fromBuffer(value),
++        ($16.GetKinematicsResponse value) => value.writeToBuffer()));
+   }
+ 
+   $async.Future<$25.OpenResponse> open_Pre($grpc.ServiceCall call, $async.Future<$25.OpenRequest> request) async {
+@@ -151,10 +166,15 @@ abstract class GripperServiceBase extends $grpc.Service {
+     return getGeometries(call, await request);
+   }
+ 
++  $async.Future<$16.GetKinematicsResponse> getKinematics_Pre($grpc.ServiceCall call, $async.Future<$16.GetKinematicsRequest> request) async {
++    return getKinematics(call, await request);
++  }
++
+   $async.Future<$25.OpenResponse> open($grpc.ServiceCall call, $25.OpenRequest request);
+   $async.Future<$25.GrabResponse> grab($grpc.ServiceCall call, $25.GrabRequest request);
+   $async.Future<$25.StopResponse> stop($grpc.ServiceCall call, $25.StopRequest request);
+   $async.Future<$25.IsMovingResponse> isMoving($grpc.ServiceCall call, $25.IsMovingRequest request);
+   $async.Future<$16.DoCommandResponse> doCommand($grpc.ServiceCall call, $16.DoCommandRequest request);
+   $async.Future<$16.GetGeometriesResponse> getGeometries($grpc.ServiceCall call, $16.GetGeometriesRequest request);
++  $async.Future<$16.GetKinematicsResponse> getKinematics($grpc.ServiceCall call, $16.GetKinematicsRequest request);
+ }

--- a/ai_updater/tests/test_ai_updater.py
+++ b/ai_updater/tests/test_ai_updater.py
@@ -35,6 +35,7 @@ SCENARIOS = [
         "description": "Added new method to component",
         "pre_implementation_commit": "8d6b63a0fade65b8054cafb849d844bcdb089761",
         "specific_proto_diff_file": True,
+        "sdk": "python",
         "repo_url": "git@github.com:viamrobotics/viam-python-sdk.git"
     },
     {
@@ -42,6 +43,7 @@ SCENARIOS = [
         "description": "Added new field to app client",
         "pre_implementation_commit": "ef8ae496df44a8e881836e76e7e953ed5e6bbd4c",
         "specific_proto_diff_file": False,
+        "sdk": "python",
         "repo_url": "git@github.com:viamrobotics/viam-python-sdk.git"
     },
     {
@@ -49,6 +51,7 @@ SCENARIOS = [
         "description": "Added entire new components (Button and Switch)",
         "pre_implementation_commit": "e8818bce81be520a740bf3da725c8d816fe2aa4b",
         "specific_proto_diff_file": False,
+        "sdk": "python",
         "repo_url": "git@github.com:viamrobotics/viam-python-sdk.git"
     },
     {
@@ -56,6 +59,7 @@ SCENARIOS = [
         "description": "Updated a version number (no changes needed)",
         "pre_implementation_commit": "cd8765e9b2d6adcdeb7ecda6c2b72940d4439d0a",
         "specific_proto_diff_file": True,
+        "sdk": "python",
         "repo_url": "git@github.com:viamrobotics/viam-python-sdk.git"
     },
     {
@@ -63,7 +67,32 @@ SCENARIOS = [
         "description": "Single field update that leads to many small changes in long file",
         "pre_implementation_commit": "7e92b134e5440f5aed861d1117ec31de118a70c9",
         "specific_proto_diff_file": True,
+        "sdk": "python",
         "repo_url": "git@github.com:viamrobotics/viam-python-sdk.git"
+    },
+    {
+        "name": "scenario-6",
+        "description": "Typescript Gripper get_kinematics",
+        "pre_implementation_commit": "c3bb320c32384f09da161dff2fc188127c5661f2",
+        "specific_proto_diff_file": False,
+        "sdk": "typescript",
+        "repo_url": "git@github.com:viamrobotics/viam-typescript-sdk.git"
+    },
+    {
+        "name": "scenario-7",
+        "description": "C++ Gripper get_kinematics",
+        "pre_implementation_commit": "e834a64f4341f10c37a974c86c8ef37a9f334a60",
+        "specific_proto_diff_file": False,
+        "sdk": "cpp",
+        "repo_url": "git@github.com:viamrobotics/viam-cpp-sdk.git"
+    },
+    {
+        "name": "scenario-8",
+        "description": "Flutter Gripper get_kinematics",
+        "pre_implementation_commit": "834b5d2c49eae812cf91e94fc39f72ed46597f5f",
+        "specific_proto_diff_file": True,
+        "sdk": "flutter",
+        "repo_url": "git@github.com:viamrobotics/viam-flutter-sdk.git"
     }
 ]
 
@@ -90,7 +119,8 @@ def _run_test_scenario(scenario, skip_comparison=True):
 
         # Runs AI updater with test flag
         python_path = sys.executable
-        subprocess.run([python_path, "../ai_updater.py", "--debug", "--test", temp_dir],
+        sdk = scenario['sdk']
+        subprocess.run([python_path, "../ai_updater.py", "--debug", "--sdk", sdk, "--test", temp_dir],
                        check=True,
                        env=os.environ.copy(),
                        cwd=tests_dir)
@@ -111,6 +141,6 @@ def _run_test_scenario(scenario, skip_comparison=True):
 
 if __name__ == "__main__":
     print("Running all scenarios for debugging...")
-    for scenario in SCENARIOS[:]: #change this to run specific scenarios if desired
+    for scenario in SCENARIOS[5:]: #change this to run specific scenarios if desired
         print(f"Running scenario: {scenario['name']}")
         _run_test_scenario(scenario) # skip_comparison defaults to True for standalone run


### PR DESCRIPTION
This PR adds support for the TypeScript, C++, and Flutter SDK's. To accomplish this the calling workflow (located in the specific SDK) will now specify what SDK it is. This leads to a couple small changes within the ai_updater.py script which account for the specific SDK's file structure. In the case of the TypeScript SDK this also requires a little more work because the proto files are not automatically in the repo and have to be manually build to get the diff to send to the AI. 

This PR also adds a test case for each of the TypeScript, C++, and Flutter SDK's.

ALSO this PR adds an AI summary to the PR to make it easier for the reviewer to understand what protos changed and why the AI added what it did. 